### PR TITLE
doc: add type casts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ CREATE TABLE items (id bigserial PRIMARY KEY, emb numeric[]);
 -- insert values
 INSERT INTO items (emb) VALUES (ARRAY[1,2,3]), (ARRAY[4,5,6]);
 -- query the similar embeddings
-SELECT * FROM items ORDER BY emb <-> ARRAY[3,2,1] LIMIT 5;
+SELECT * FROM items ORDER BY emb <-> ARRAY[3,2,1]::real[] LIMIT 5;
 -- query the neighbors within a certain distance
-SELECT * FROM items WHERE emb <-> ARRAY[3,2,1] < 5;
+SELECT * FROM items WHERE emb <-> ARRAY[3,2,1]::real[] < 5;
 ```
 
 ### Create an index


### PR DESCRIPTION
try to fix #26 by adding type casts to queries in README `create table` section