### PR TITLE
feat: udf ai_embedding_vector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ openai_api_rust = "0.1.8"
 
 [dev-dependencies]
 pgrx-tests = "=0.8.3"
+httpmock = "0.6"
+serde_json = "1"
+mockall = "0.11.4"
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.8.0"
+pgrx = "=0.8.3"
+openai_api_rust = "0.1.8"
 
 [dev-dependencies]
-pgrx-tests = "=0.8.0"
+pgrx-tests = "=0.8.3"
 
 [profile.dev]
 panic = "unwind"

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -1,0 +1,64 @@
+use openai_api_rust::{
+    embeddings::{EmbeddingsApi, EmbeddingsBody},
+    Auth, OpenAI,
+};
+
+pub(crate) type Embedding = Vec<f64>;
+pub(crate) type Embeddings = Vec<Embedding>;
+
+const OPENAI_API_URL_BASE: &str = "https://api.openai.com/v1/";
+
+pub(crate) enum EmbeddingModel {
+    // the most used OpenAI embedding model
+    Ada002,
+}
+
+impl ToString for EmbeddingModel {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Ada002 => "text-embedding-ada-002".to_string(),
+        }
+    }
+}
+
+pub(crate) struct OpenAIEmbedding {
+    api_key: String,
+    api_url: String,
+    model: EmbeddingModel,
+}
+
+impl OpenAIEmbedding {
+    pub(crate) fn new_ada002(api_key: String) -> Self {
+        Self::new(api_key, EmbeddingModel::Ada002)
+    }
+
+    pub(crate) fn new(api_key: String, model: EmbeddingModel) -> Self {
+        Self {
+            api_key,
+            model,
+            api_url: OPENAI_API_URL_BASE.to_string(),
+        }
+    }
+
+    pub(crate) fn create_embeddings(&self, input: Vec<String>) -> Result<Embeddings, String> {
+        let auth = Auth::new(&self.api_key);
+        let client = OpenAI::new(auth, &self.api_url);
+
+        let embeddings = client
+            .embeddings_create(&EmbeddingsBody {
+                model: self.model.to_string(),
+                input,
+                user: None,
+            })
+            .map_err(|e| e.to_string())?;
+
+        let data: Embeddings = embeddings
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(|data| data.embedding.unwrap_or_default())
+            .collect();
+
+        Ok(data)
+    }
+}

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -6,6 +6,13 @@ use openai_api_rust::{
 pub(crate) type Embedding = Vec<f64>;
 pub(crate) type Embeddings = Vec<Embedding>;
 
+#[cfg(test)]
+use mockall::automock;
+#[cfg_attr(test, automock)]
+pub(crate) trait EmbeddingCreator {
+    fn create_embeddings(&self, input: Vec<String>) -> Result<Embeddings, String>;
+}
+
 const OPENAI_API_URL_BASE: &str = "https://api.openai.com/v1/";
 
 pub(crate) enum EmbeddingModel {
@@ -29,20 +36,26 @@ pub(crate) struct OpenAIEmbedding {
 
 impl OpenAIEmbedding {
     pub(crate) fn new_ada002(api_key: String) -> Self {
-        Self::new(api_key, EmbeddingModel::Ada002)
+        Self::new(
+            api_key,
+            EmbeddingModel::Ada002,
+            OPENAI_API_URL_BASE.to_string(),
+        )
     }
 
-    pub(crate) fn new(api_key: String, model: EmbeddingModel) -> Self {
+    pub(crate) fn new(api_key: String, model: EmbeddingModel, api_url: String) -> Self {
         Self {
             api_key,
             model,
-            api_url: OPENAI_API_URL_BASE.to_string(),
+            api_url,
         }
     }
+}
 
-    pub(crate) fn create_embeddings(&self, input: Vec<String>) -> Result<Embeddings, String> {
+impl EmbeddingCreator for OpenAIEmbedding {
+    fn create_embeddings(&self, input: Vec<String>) -> Result<Embeddings, String> {
         let auth = Auth::new(&self.api_key);
-        let client = OpenAI::new(auth, &self.api_url);
+        let client = OpenAI::new(auth, &self.api_url).use_env_proxy();
 
         let embeddings = client
             .embeddings_create(&EmbeddingsBody {
@@ -60,5 +73,56 @@ impl OpenAIEmbedding {
             .collect();
 
         Ok(data)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use httpmock::MockServer;
+    use serde_json::json;
+
+    use crate::embedding::{Embedding, EmbeddingCreator};
+
+    use super::OpenAIEmbedding;
+
+    #[test]
+    fn test_create_embeddings() {
+        let input: String = "hello".to_string();
+        let expected_emb: Embedding = vec![0.151240, 0.1231224123, 0.231253124, 0.213125];
+        let server = MockServer::start();
+
+        let emb_mock = server.mock(|when, then| {
+            when.path("/embeddings");
+            then.json_body(format_output_json(expected_emb.clone()));
+        });
+
+        let client = OpenAIEmbedding::new(
+            "".to_string(),
+            crate::embedding::EmbeddingModel::Ada002,
+            server.base_url() + "/",
+        );
+
+        let mut embs = client.create_embeddings(vec![input]).unwrap();
+
+        let emb = embs.pop().unwrap();
+        assert_eq!(emb, expected_emb);
+        emb_mock.assert();
+    }
+
+    fn format_output_json(embedding: Embedding) -> serde_json::Value {
+        json!({
+          "data": [
+            {
+              "embedding": embedding,
+              "index": 0,
+              "object": "embedding"
+            }
+          ],
+          "model": "text-embedding-ada-002",
+          "object": "list",
+          "usage": {
+            "prompt_tokens": 0,
+            "total_tokens": 0
+          }
+        })
     }
 }

--- a/src/gucs.rs
+++ b/src/gucs.rs
@@ -1,0 +1,16 @@
+use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting};
+
+// GUC setting for OpenAI API key
+pub(crate) static OPENAI_API_KEY_GUC: GucSetting<Option<&'static str>> = GucSetting::new(None);
+
+// register guc
+pub(crate) fn init() {
+    GucRegistry::define_string_guc(
+        "openai_api_key",
+        "The API key of OpenAI",
+        "The OpenAI API key is required to use OpenAI embedding",
+        &OPENAI_API_KEY_GUC,
+        GucContext::Userset,
+        GucFlags::default(),
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,19 @@
 
 use pgrx::prelude::*;
 
+mod embedding;
+mod gucs;
 mod index;
 mod operator;
+mod udf;
 
 pgrx::pg_module_magic!();
+
+#[allow(non_snake_case)]
+#[pg_guard]
+pub unsafe extern "C" fn _PG_init() {
+    gucs::init();
+}
 
 /// This module is required by `cargo pgrx test` invocations.
 /// It must be visible at the root of your extension crate.

--- a/src/udf.rs
+++ b/src/udf.rs
@@ -1,0 +1,41 @@
+use pgrx::prelude::*;
+
+use crate::{
+    embedding::{Embedding, OpenAIEmbedding},
+    gucs::OPENAI_API_KEY_GUC,
+};
+
+#[pg_extern(immutable)]
+fn ai_embedding_vector(input: String) -> Embedding {
+    let api_key = match OPENAI_API_KEY_GUC.get() {
+        Some(key) => key,
+        None => {
+            error!("openai_api_key is not set");
+        }
+    };
+
+    // default to use ada002
+    let openai_embedding = OpenAIEmbedding::new_ada002(api_key);
+
+    match openai_embedding.create_embeddings(vec![input]) {
+        Ok(mut embeddings) => match embeddings.pop() {
+            Some(embedding) => embedding,
+            None => {
+                error!("embedding is empty")
+            }
+        },
+        Err(e) => {
+            error!("failed to create embedding, {}", e)
+        }
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    // We need to mock embedding requests since it requires an API key.
+    #[pg_test]
+    fn test_ai_embedding_vector() {}
+}

--- a/src/udf.rs
+++ b/src/udf.rs
@@ -1,11 +1,11 @@
 use pgrx::prelude::*;
 
 use crate::{
-    embedding::{Embedding, OpenAIEmbedding},
+    embedding::{Embedding, EmbeddingCreator, OpenAIEmbedding},
     gucs::OPENAI_API_KEY_GUC,
 };
 
-#[pg_extern(immutable)]
+#[pg_extern]
 fn ai_embedding_vector(input: String) -> Embedding {
     let api_key = match OPENAI_API_KEY_GUC.get() {
         Some(key) => key,
@@ -17,25 +17,76 @@ fn ai_embedding_vector(input: String) -> Embedding {
     // default to use ada002
     let openai_embedding = OpenAIEmbedding::new_ada002(api_key);
 
-    match openai_embedding.create_embeddings(vec![input]) {
-        Ok(mut embeddings) => match embeddings.pop() {
-            Some(embedding) => embedding,
-            None => {
-                error!("embedding is empty")
-            }
-        },
+    match ai_embedding_vector_inner(input, openai_embedding) {
+        Ok(embedding) => embedding,
         Err(e) => {
-            error!("failed to create embedding, {}", e)
+            error!("{}", e)
         }
     }
 }
 
-#[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
-mod tests {
-    use pgrx::prelude::*;
+fn ai_embedding_vector_inner(
+    input: String,
+    client: impl EmbeddingCreator,
+) -> Result<Embedding, String> {
+    match client.create_embeddings(vec![input]) {
+        Ok(mut embeddings) => match embeddings.pop() {
+            Some(embedding) => Ok(embedding),
+            None => Err("embedding is empty".to_string()),
+        },
+        Err(e) => Err(format!("failed to create embedding, {}", e)),
+    }
+}
 
-    // We need to mock embedding requests since it requires an API key.
-    #[pg_test]
-    fn test_ai_embedding_vector() {}
+#[cfg(test)]
+mod tests {
+    use crate::embedding::MockEmbeddingCreator;
+    use crate::udf::ai_embedding_vector_inner;
+    use mockall::predicate::eq;
+
+    // We need to mock embedding since it requires an API key.
+    #[test]
+    fn test_ai_embedding_vector_inner_successful() {
+        let input = String::from("input");
+        let mut mock_client = MockEmbeddingCreator::new();
+        let expected_embedding = vec![1.0, 2.0, 3.0];
+        mock_client
+            .expect_create_embeddings()
+            .with(eq(vec![input.clone()]))
+            .returning(|_| Ok(vec![vec![1.0, 2.0, 3.0]]));
+
+        let result = ai_embedding_vector_inner(input, mock_client);
+
+        assert_eq!(result, Ok(expected_embedding));
+    }
+
+    #[test]
+    fn test_ai_embedding_vector_inner_empty_embedding() {
+        let input = String::from("input");
+        let mut mock_client = MockEmbeddingCreator::new();
+        mock_client
+            .expect_create_embeddings()
+            .with(eq(vec![input.clone()]))
+            .returning(|_| Ok(vec![]));
+
+        let result = ai_embedding_vector_inner(input, mock_client);
+        assert_eq!(result, Err("embedding is empty".to_string()))
+    }
+
+    #[test]
+    fn test_ai_embedding_vector_inner_error() {
+        let input = String::from("input");
+        let mut mock_client = MockEmbeddingCreator::new();
+        mock_client
+            .expect_create_embeddings()
+            .with(eq(vec![input.clone()]))
+            .returning(|_| Err(String::from("invalid input")));
+
+        let result = ai_embedding_vector_inner(input, mock_client);
+
+        assert_eq!(
+            result,
+            Err("failed to create embedding, invalid input".to_string())
+        )
+    }
 }


### PR DESCRIPTION
#23 
This PR adds the `ai_embedding_vector` UDF which depends on OpenAI Ada002.


Example:
First, set openai_api_key
```
SET openai_api_key=<your-api-key>;
```

Query
```sql
SELECT ai_embedding_vector('hello') <-> ai_embedding_vector('hallo');
```
Output
```
      ?column?       
---------------------
 0.29756917700636787
(1 row)
```


More complicated example
```sql
CREATE TABLE documents (id bigserial PRIMARY KEY, content VARCHAR, emb numeric[]);

INSERT INTO documents (content) VALUES ('Hello World!'), ('Rust Power'), ('Python World');

UPDATE documents SET emb = ai_embedding_vector(content);

SELECT content FROM documents ORDER BY emb <-> ai_embedding_vector("World") LIMIT 2;
```
Output is
```
   content    
--------------
 Hello World!
 Python World
(2 rows)
```