### PR TITLE
feat: support pg11 and pg12

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [13]
+        version: [12, 13]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -44,10 +44,11 @@ jobs:
         cargo install cargo-pgrx --version "0.8.0"
         cargo pgrx init --pg${{ matrix.version }}=download
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --no-default-features --features "pg${{ matrix.version }}" --verbose
     - name: Semantic check
-      run: cargo clippy
+      run: cargo clippy --no-default-features --features "pg${{ matrix.version }}" 
     - name: Test
       env:
         RUST_BACKTRACE: 1
       run: cargo test --all --no-default-features --features "pg${{ matrix.version }} pg_test" -- --nocapture
+ 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -20,7 +20,6 @@ fn am_handler(_fc_info: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutin
 
     am_routine.amstrategies = 3;
     am_routine.amsupport = 1;
-    am_routine.amoptsprocnum = 0;
 
     am_routine.amcanorder = false;
     am_routine.amcanorderbyop = true;
@@ -34,7 +33,11 @@ fn am_handler(_fc_info: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRoutin
     am_routine.amclusterable = false;
     am_routine.ampredlocks = true;
     am_routine.amcaninclude = false;
-    am_routine.amusemaintenanceworkmem = false;
+    #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+    {
+        am_routine.amoptsprocnum = 0;
+        am_routine.amusemaintenanceworkmem = false;
+    }
     am_routine.amkeytype = pgrx::pg_sys::InvalidOid;
 
     am_routine.amvalidate = Some(am_validate);


### PR DESCRIPTION
`am_routine.amusemaintenanceworkmem`and `am_routine.amoptsprocnum` added in pg13

also add CI and fix the old CI for it.

passed CI can check: https://github.com/yihong0618/pgvecto.rs/actions/runs/5400551415

fix #34 

 Signed-off-by: yihong0618 <zouzou0208@gmail.com>