### PR TITLE
Update sql in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ $$);
 Now you can perform a KNN search with the following SQL simply.
 
 ```sql
-SELECT *, emb <-> '[0, 0, 0]' AS score
+SELECT *, embedding <-> '[0, 0, 0]' AS score
 FROM items
 ORDER BY embedding <-> '[0, 0, 0]' LIMIT 10;
 ```


### PR DESCRIPTION
Following the example in readme, there is no column called `emb` so updated it to the correct name.