### PR TITLE
fix: use x86-64-v3 as target cpu

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = ["-Ctarget-cpu=native"]
+rustflags = ["-Ctarget-cpu=x86-64-v3"]
 rustdocflags = ["--document-private-items"]
 
 [target.'cfg(target_os="macos")']


### PR DESCRIPTION
Currently releases built by GitHub runners cannot run on machines without AVX-512 instructions. "x86-64-v3" relaxs the restriction for target instruction sets.