### PR TITLE
feat: add GUC option to manually control filter mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ SET vectors.k = 32;
 SET LOCAL vectors.k = 32;
 ```
 
+If you want to disable vector indexing or prefilter, we also offer some GUC options:
+- `vectors.enable_vector_index`: Enable or disable the vector index. Default value is `on`.
+- `vectors.enable_prefilter`: Enable or disable the prefilter. Default value is `on`.
 
 ## Limitations
 

--- a/src/postgres/gucs.rs
+++ b/src/postgres/gucs.rs
@@ -1,4 +1,4 @@
-use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting, PostgresGucEnum};
+use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting};
 use std::ffi::CStr;
 
 pub static OPENAI_API_KEY_GUC: GucSetting<Option<&'static CStr>> =
@@ -6,15 +6,9 @@ pub static OPENAI_API_KEY_GUC: GucSetting<Option<&'static CStr>> =
 
 pub static K: GucSetting<i32> = GucSetting::<i32>::new(64);
 
-pub static FILTER_MODE: GucSetting<FilterMode> =
-    GucSetting::<FilterMode>::new(FilterMode::Prefilter);
+pub static ENABLE_VECTOR_INDEX: GucSetting<bool> = GucSetting::<bool>::new(true);
 
-#[derive(PostgresGucEnum, PartialEq, Eq, Clone, Copy)]
-pub enum FilterMode {
-    Skip,
-    Prefilter,
-    Postfilter,
-}
+pub static ENABLE_PREFILTER: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 pub unsafe fn init() {
     GucRegistry::define_string_guc(
@@ -35,11 +29,19 @@ pub unsafe fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
-    GucRegistry::define_enum_guc(
-        "vectors.filter_mode",
-        "The filter mode for vector index",
-        "The filter mode for vector index",
-        &FILTER_MODE,
+    GucRegistry::define_bool_guc(
+        "vectors.enable_vector_index",
+        "Whether to enable vector index.",
+        "When enabled, it will use existing vector index to speed up the search.",
+        &ENABLE_PREFILTER,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_bool_guc(
+        "vectors.enable_prefilter",
+        "Whether to enable prefilter.",
+        "When enabled, it will use prefilter to reduce the number of vectors to search.",
+        &ENABLE_PREFILTER,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/src/postgres/gucs.rs
+++ b/src/postgres/gucs.rs
@@ -1,10 +1,20 @@
-use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting};
+use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting, PostgresGucEnum};
 use std::ffi::CStr;
 
 pub static OPENAI_API_KEY_GUC: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
 
 pub static K: GucSetting<i32> = GucSetting::<i32>::new(64);
+
+pub static FILTER_MODE: GucSetting<FilterMode> =
+    GucSetting::<FilterMode>::new(FilterMode::Prefilter);
+
+#[derive(PostgresGucEnum, PartialEq, Eq, Clone, Copy)]
+pub enum FilterMode {
+    Skip,
+    Prefilter,
+    Postfilter,
+}
 
 pub unsafe fn init() {
     GucRegistry::define_string_guc(
@@ -22,6 +32,14 @@ pub unsafe fn init() {
         &K,
         1,
         u16::MAX as _,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_enum_guc(
+        "vectors.filter_mode",
+        "The filter mode for vector index",
+        "The filter mode for vector index",
+        &FILTER_MODE,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/src/postgres/index.rs
+++ b/src/postgres/index.rs
@@ -3,6 +3,8 @@ use super::index_scan;
 use super::index_setup;
 use super::index_update;
 use crate::postgres::datatype::VectorInput;
+use crate::postgres::gucs::FILTER_MODE;
+use crate::postgres::gucs::FilterMode;
 use crate::prelude::*;
 use std::cell::Cell;
 
@@ -160,7 +162,7 @@ pub unsafe extern "C" fn amcostestimate(
     index_correlation: *mut f64,
     index_pages: *mut f64,
 ) {
-    if (*path).indexorderbys.is_null() {
+    if (*path).indexorderbys.is_null() || FILTER_MODE.get() == FilterMode::Skip {
         *index_startup_cost = f64::MAX;
         *index_total_cost = f64::MAX;
         *index_selectivity = 0.0;

--- a/src/postgres/index.rs
+++ b/src/postgres/index.rs
@@ -3,8 +3,8 @@ use super::index_scan;
 use super::index_setup;
 use super::index_update;
 use crate::postgres::datatype::VectorInput;
-use crate::postgres::gucs::FILTER_MODE;
 use crate::postgres::gucs::FilterMode;
+use crate::postgres::gucs::FILTER_MODE;
 use crate::prelude::*;
 use std::cell::Cell;
 

--- a/src/postgres/index.rs
+++ b/src/postgres/index.rs
@@ -3,8 +3,7 @@ use super::index_scan;
 use super::index_setup;
 use super::index_update;
 use crate::postgres::datatype::VectorInput;
-use crate::postgres::gucs::FilterMode;
-use crate::postgres::gucs::FILTER_MODE;
+use crate::postgres::gucs::ENABLE_VECTOR_INDEX;
 use crate::prelude::*;
 use std::cell::Cell;
 
@@ -162,7 +161,7 @@ pub unsafe extern "C" fn amcostestimate(
     index_correlation: *mut f64,
     index_pages: *mut f64,
 ) {
-    if (*path).indexorderbys.is_null() || FILTER_MODE.get() == FilterMode::Skip {
+    if (*path).indexorderbys.is_null() || !ENABLE_VECTOR_INDEX.get() {
         *index_startup_cost = f64::MAX;
         *index_total_cost = f64::MAX;
         *index_selectivity = 0.0;

--- a/src/postgres/index_scan.rs
+++ b/src/postgres/index_scan.rs
@@ -3,6 +3,7 @@ use crate::postgres::gucs::K;
 use crate::prelude::*;
 use pgrx::FromDatum;
 
+use super::gucs::{FilterMode, FILTER_MODE};
 use super::hook_transaction::client;
 
 #[derive(Debug, Clone)]
@@ -133,8 +134,9 @@ pub unsafe fn next_scan(scan: pgrx::pg_sys::IndexScanDesc) -> bool {
         let oid = (*(*scan).indexRelation).rd_id;
         let id = Id::from_sys(oid);
         let vector = vector.expect("`rescan` is never called.");
-        if let Some(index_scan_state) = index_scan_state {
+        if index_scan_state.is_some() && FILTER_MODE.get() == FilterMode::Prefilter {
             client(|rpc| {
+                let index_scan_state = index_scan_state.unwrap();
                 let k = K.get() as _;
                 let mut handler = rpc.search(id, vector, k).unwrap();
                 let mut res;

--- a/src/postgres/index_scan.rs
+++ b/src/postgres/index_scan.rs
@@ -1,10 +1,9 @@
+use super::gucs::ENABLE_PREFILTER;
+use super::hook_transaction::client;
 use crate::postgres::datatype::VectorInput;
 use crate::postgres::gucs::K;
 use crate::prelude::*;
 use pgrx::FromDatum;
-
-use super::gucs::{FilterMode, FILTER_MODE};
-use super::hook_transaction::client;
 
 #[derive(Debug, Clone)]
 pub enum Scanner {
@@ -134,7 +133,7 @@ pub unsafe fn next_scan(scan: pgrx::pg_sys::IndexScanDesc) -> bool {
         let oid = (*(*scan).indexRelation).rd_id;
         let id = Id::from_sys(oid);
         let vector = vector.expect("`rescan` is never called.");
-        if index_scan_state.is_some() && FILTER_MODE.get() == FilterMode::Prefilter {
+        if index_scan_state.is_some() && ENABLE_PREFILTER.get() {
             client(|rpc| {
                 let index_scan_state = index_scan_state.unwrap();
                 let k = K.get() as _;


### PR DESCRIPTION
close #65

## test
When using skip mode,
```
explain select train.id from train order by 'a long vector' <=> train.embedding limit 32;
 Limit  (cost=490.54..499.02 rows=32 width=12)
   ->  Result  (cost=490.54..1815.81 rows=5001 width=12)
         ->  Sort  (cost=490.54..503.05 rows=5001 width=8)
               Sort Key: (('a long vector'::vector <=> embedding))
               ->  Seq Scan on train  (cost=0.00..340.51 rows=5001 width=8)
```

When using prefilter/postfilter, 
```
explain select train.id from train order by 'a long vector' <=> train.embedding limit 32;
 Limit  (cost=0.00..10.20 rows=32 width=12)
   ->  Index Scan using train_embedding_idx on train  (cost=0.00..1593.76 rows=5001 width=12)
         Order By: (embedding <=> 'a long vector'::vector)
```

And when using postfilter, it will output "Fallback to post-filter." like https://github.com/tensorchord/pgvecto.rs/blob/d96a11419a704388cd34545959d4f3962ac206e8/src/postgres/index_scan.rs#L162