### PR TITLE
ci: run ci when updating tests dir

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,14 +37,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Prepare
-      run: |
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update
-        sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
-        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
-        cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
+    - uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+        restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
     - name: Format check
       run: cargo fmt --check
     - name: Semantic check
@@ -57,14 +59,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: ankane/setup-postgres@v1
+      with:
+        postgres-version: ${{ matrix.version }}
+        dev-files: true
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+        restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update
-        sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
-        cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
+        cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
     - name: Build
       run: cargo build --verbose
     - name: Test
@@ -84,6 +96,16 @@ jobs:
         postgres-version: ${{ matrix.version }}
         database: testdb
         dev-files: true
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+        restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
@@ -96,5 +118,6 @@ jobs:
         cargo pgrx install --release
     - name: Sqllogictest
       run: |
+        sudo systemctl restart postgresql@${{ matrix.version }}-main
         psql -d testdb -f ./tests/init.sql
-        sqllogictest -d testdb './tests/**/*.slt'
+        sqllogictest -d testdb -w "" './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -114,7 +114,6 @@ jobs:
     - name: Prepare
       run: |
         sudo pg_dropcluster 14 main
-        sudo apt-get --purge remove postgresql
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         sudo apt-get update
@@ -136,8 +135,8 @@ jobs:
         sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
         cargo pgrx install --release
         sudo systemctl start postgresql@${{ matrix.version }}-main
-        sudo -u postgres psql -c 'CREATE USER $USER LOGIN SUPERUSER'
-        sudo -u postgres psql -c 'CREATE DATABASE $USER OWNER $USER'
+        sudo -u postgres psql -c "CREATE USER $USER LOGIN SUPERUSER"
+        sudo -u postgres psql -c "CREATE DATABASE $USER OWNER $USER"
         psql -c 'ALTER SYSTEM SET shared_preload_libraries = "vectors.so"'
         sudo systemctl restart postgresql@${{ matrix.version }}-main
     - name: Sqllogictest
@@ -145,4 +144,4 @@ jobs:
         export password=$(openssl rand -base64 32)
         psql -c "ALTER USER $USER WITH PASSWORD '$password'"
         psql -f ./tests/init.sql
-        sqllogictest -u $USER -w $password -d $USER './tests/**/*.slt'
+        sqllogictest -u "$USER" -w "$password" -d "$USER" './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,7 +97,7 @@ jobs:
       run: |
         sudo systemctl restart postgresql
         export password=$(openssl rand -base64 32)
-        sudo -u postgres psql -c "CREATE ROLE $USER WITH LOGIN PASSWORD $password SUPERUSER"
+        sudo -u postgres psql -c "CREATE ROLE $USER WITH LOGIN PASSWORD '$password' SUPERUSER"
         sudo -u postgres createdb $USER
         psql -f ./tests/init.sql
         sqllogictest -u $USER -w $password -d $USER './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,25 +79,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: ankane/setup-postgres@v1
+      with:
+        postgres-version: ${{ matrix.version }}
+        dev-files: true
     - name: Prepare
       run: |
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update
-        sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
-        cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
+        cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
         cargo install sqllogictest-bin
-    - name: Build && Install
-      run: |
-        sudo chmod 777 /usr/share/postgresql/${{ matrix.version }}/extension/
-        sudo chmod 777 /usr/lib/postgresql/${{ matrix.version }}/lib
-        cargo pgrx install --release
+    - name: Build
+      run: cargo pgrx install --release
     - name: Sqllogictest
       run: |
-        sudo systemctl restart postgresql
-        export password=$(openssl rand -base64 32)
-        sudo -u postgres psql -c "CREATE ROLE $USER WITH LOGIN PASSWORD '$password' SUPERUSER"
-        sudo -u postgres createdb $USER
         psql -f ./tests/init.sql
-        sqllogictest -u $USER -w $password -d $USER './tests/**/*.slt'
+        sqllogictest -d testdb './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main" ]
     paths:
+      - '.github/workflows/check.yml'
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
+      - '.github/workflows/check.yml'
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -87,7 +89,7 @@ jobs:
         cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
         cargo install sqllogictest-bin
     - name: Build && Install
-      run: cargo pgrx install --release
+      run: sudo cargo pgrx install --release
     - name: Sqllogictest
       run: |
         sudo systemctl restart postgresql

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,8 +45,12 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
         restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
+    - name: Prepare
+      run: |
+        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
+        cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
     - name: Format check
       run: cargo fmt --check
     - name: Semantic check
@@ -71,7 +75,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
         restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
@@ -104,7 +108,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+        key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
         restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
@@ -116,8 +120,11 @@ jobs:
         sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension
         sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
         cargo pgrx install --release
+        psql -c 'ALTER SYSTEM SET shared_preload_libraries = "vectors.so"'
+        sudo systemctl restart postgresql@${{ matrix.version }}-main
     - name: Sqllogictest
       run: |
-        sudo systemctl restart postgresql@${{ matrix.version }}-main
+        export password=$(openssl rand -base64 32)
+        psql -c "ALTER USER $USER WITH PASSWORD '$password'"
         psql -d testdb -f ./tests/init.sql
-        sqllogictest -d testdb -w "" './tests/**/*.slt'
+        sqllogictest -u $USER -w $password -d testdb './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,7 +90,7 @@ jobs:
         cargo install sqllogictest-bin
     - name: Build && Install
       run: |
-        sudo chmod +w /usr/share/postgresql/${{ matrix.version }}/extension/
+        sudo chmod 777 /usr/share/postgresql/${{ matrix.version }}/extension/
         cargo pgrx install --release
     - name: Sqllogictest
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'tests/**'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -15,6 +16,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'tests/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,6 +28,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: true
+  RUSTC_WRAPPER: sccache
 
 jobs:
   lint:
@@ -44,11 +46,15 @@ jobs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          target/
-        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
-        restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
+        key: cargo-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
+        restore-keys: cargo-${{ runner.os }}-pg${{ matrix.version }}
+    - uses: mozilla-actions/sccache-action@v0.0.3
     - name: Prepare
       run: |
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
         cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
     - name: Format check
@@ -63,16 +69,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/cache/restore@v3
       with:
         path: |
           ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          target/
-        key: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
-        restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
+        key: cargo-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
+        restore-keys: cargo-${{ runner.os }}-pg${{ matrix.version }}
+    - uses: mozilla-actions/sccache-action@v0.0.3
     - name: Prepare
       run: |
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -102,9 +108,9 @@ jobs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-          target/
-        key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
-        restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
+        key: cargo-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
+        restore-keys: cargo-${{ runner.os }}-pg${{ matrix.version }}
+    - uses: mozilla-actions/sccache-action@v0.0.3
     - name: Prepare
       run: |
         sudo apt-get --purge remove postgresql
@@ -120,6 +126,7 @@ jobs:
         sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension
         sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
         cargo pgrx install --release
+        sudo systemctl start postgresql@${{ matrix.version }}-main
         sudo -u postgres createuser -s -w $USER
         sudo -u postgres createdb $USER
         psql -c 'ALTER SYSTEM SET shared_preload_libraries = "vectors.so"'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/cache/restore@v3
       with:
         path: |
           ~/.cargo/bin/
@@ -113,6 +113,7 @@ jobs:
     - uses: mozilla-actions/sccache-action@v0.0.3
     - name: Prepare
       run: |
+        sudo pg_dropcluster 14 main
         sudo apt-get --purge remove postgresql
         sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
@@ -121,14 +122,22 @@ jobs:
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
         cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
         cargo install sqllogictest-bin || true
+    - uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
     - name: Build
       run: |
         sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension
         sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
         cargo pgrx install --release
         sudo systemctl start postgresql@${{ matrix.version }}-main
-        sudo -u postgres createuser -s -w $USER
-        sudo -u postgres createdb $USER
+        sudo -u postgres psql -c 'CREATE USER $USER LOGIN SUPERUSER'
+        sudo -u postgres psql -c 'CREATE DATABASE $USER OWNER $USER'
         psql -c 'ALTER SYSTEM SET shared_preload_libraries = "vectors.so"'
         sudo systemctl restart postgresql@${{ matrix.version }}-main
     - name: Sqllogictest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,7 +97,7 @@ jobs:
       run: |
         sudo systemctl restart postgresql
         export password=$(openssl rand -base64 32)
-        sudo -u postgres psql -c 'CREATE ROLE $USER WITH LOGIN PASSWORD $password SUPERUSER'
+        sudo -u postgres psql -c "CREATE ROLE $USER WITH LOGIN PASSWORD $password SUPERUSER"
         sudo -u postgres createdb $USER
         psql -f ./tests/init.sql
         sqllogictest -u $USER -w $password -d $USER './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,6 +82,7 @@ jobs:
     - uses: ankane/setup-postgres@v1
       with:
         postgres-version: ${{ matrix.version }}
+        database: testdb
         dev-files: true
     - name: Prepare
       run: |
@@ -95,5 +96,5 @@ jobs:
         cargo pgrx install --release
     - name: Sqllogictest
       run: |
-        psql -f ./tests/init.sql
+        psql -d testdb -f ./tests/init.sql
         sqllogictest -d testdb './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,10 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ankane/setup-postgres@v1
-      with:
-        postgres-version: ${{ matrix.version }}
-        dev-files: true
     - uses: actions/cache@v3
       with:
         path: |
@@ -79,6 +75,10 @@ jobs:
         restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
         cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
     - name: Build
@@ -95,11 +95,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ankane/setup-postgres@v1
-      with:
-        postgres-version: ${{ matrix.version }}
-        database: testdb
-        dev-files: true
     - uses: actions/cache@v3
       with:
         path: |
@@ -112,6 +107,11 @@ jobs:
         restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
+        sudo apt-get --purge remove postgresql
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
         cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
         cargo install sqllogictest-bin || true
@@ -120,11 +120,13 @@ jobs:
         sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension
         sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
         cargo pgrx install --release
+        sudo -u postgres createuser -s -w $USER
+        sudo -u postgres createdb $USER
         psql -c 'ALTER SYSTEM SET shared_preload_libraries = "vectors.so"'
         sudo systemctl restart postgresql@${{ matrix.version }}-main
     - name: Sqllogictest
       run: |
         export password=$(openssl rand -base64 32)
         psql -c "ALTER USER $USER WITH PASSWORD '$password'"
-        psql -d testdb -f ./tests/init.sql
-        sqllogictest -u $USER -w $password -d testdb './tests/**/*.slt'
+        psql -f ./tests/init.sql
+        sqllogictest -u $USER -w $password -d $USER './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,7 +49,7 @@ jobs:
         restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
-        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
+        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
         cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
     - name: Format check
       run: cargo fmt --check
@@ -79,7 +79,7 @@ jobs:
         restore-keys: cargo-debug-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
-        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
+        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
         cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
     - name: Build
       run: cargo build --verbose
@@ -112,9 +112,9 @@ jobs:
         restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
     - name: Prepare
       run: |
-        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
+        cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
         cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
-        cargo install sqllogictest-bin
+        cargo install sqllogictest-bin || true
     - name: Build
       run: |
         sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -89,9 +89,14 @@ jobs:
         cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
         cargo install sqllogictest-bin
     - name: Build && Install
-      run: sudo cargo pgrx install --release
+      run: |
+        sudo chmod +w /usr/share/postgresql/${{ matrix.version }}/extension/
+        cargo pgrx install --release
     - name: Sqllogictest
       run: |
         sudo systemctl restart postgresql
-        sudo -u postgres psql -f tests/init.sql
-        sudo -u postgres sqllogictest './tests/**/*.slt'
+        export password=$(openssl rand -base64 32)
+        sudo -u postgres psql -c 'CREATE ROLE $USER WITH LOGIN PASSWORD $password SUPERUSER'
+        sudo -u postgres createdb $USER
+        psql -f ./tests/init.sql
+        sqllogictest -u $USER -w $password -d $USER './tests/**/*.slt'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Prepare
       run: |
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
-        cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
+        cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
     - name: Format check
       run: cargo fmt --check
     - name: Semantic check
@@ -80,7 +80,7 @@ jobs:
     - name: Prepare
       run: |
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
-        cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
+        cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
     - name: Build
       run: cargo build --verbose
     - name: Test
@@ -113,7 +113,7 @@ jobs:
     - name: Prepare
       run: |
         cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
-        cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
+        cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
         cargo install sqllogictest-bin || true
     - name: Build
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,9 +90,9 @@ jobs:
         cargo install sqllogictest-bin
     - name: Build
       run: |
-      sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension
-      sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
-      cargo pgrx install --release
+        sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension
+        sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
+        cargo pgrx install --release
     - name: Sqllogictest
       run: |
         psql -f ./tests/init.sql

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -91,6 +91,7 @@ jobs:
     - name: Build && Install
       run: |
         sudo chmod 777 /usr/share/postgresql/${{ matrix.version }}/extension/
+        sudo chmod 777 /usr/lib/postgresql/${{ matrix.version }}/lib
         cargo pgrx install --release
     - name: Sqllogictest
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -89,7 +89,10 @@ jobs:
         cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
         cargo install sqllogictest-bin
     - name: Build
-      run: cargo pgrx install --release
+      run: |
+      sudo chmod -R 777 /usr/share/postgresql/${{ matrix.version }}/extension
+      sudo chmod -R 777 /usr/lib/postgresql/${{ matrix.version }}/lib
+      cargo pgrx install --release
     - name: Sqllogictest
       run: |
         psql -f ./tests/init.sql

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,24 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.setup.outputs.ref }}
+      - uses: ankane/setup-postgres@v1
+        with:
+          postgres-version: ${{ matrix.version }}
+          dev-files: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+          restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
       - name: Prepare
         run: |
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
           cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
-          cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
+          cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
       - name: Build Release
         id: build_release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.setup.outputs.ref }}
-      - uses: ankane/setup-postgres@v1
-        with:
-          postgres-version: ${{ matrix.version }}
-          dev-files: true
       - uses: actions/cache/restore@v3
         with:
           path: |
@@ -123,6 +119,10 @@ jobs:
           restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
       - name: Prepare
         run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install libpq-dev postgresql-${{ matrix.version }} postgresql-server-dev-${{ matrix.version }}
           cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
           cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
       - name: Build Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: true
+  RUSTC_WRAPPER: sccache
 
 jobs:
   setup:
@@ -114,9 +116,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
-          restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
+          key: cargo-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
+          restore-keys: cargo-${{ runner.os }}-pg${{ matrix.version }}
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Prepare
         run: |
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Prepare
         run: |
           cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
-          cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
+          cargo pgrx init --pg${{ matrix.version }}=/usr/lib/postgresql/${{ matrix.version }}/bin/pg_config
       - name: Build Release
         id: build_release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
       - name: Prepare
         run: |
-          cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1)
+          cargo install cargo-pgrx --git https://github.com/tensorchord/pgrx.git --rev $(cat Cargo.toml | grep "pgrx =" | awk -F'rev = "' '{print $2}' | cut -d'"' -f1) || true
           cargo pgrx init --pg${{ matrix.version }}=$(which pg_config)
       - name: Build Release
         id: build_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           postgres-version: ${{ matrix.version }}
           dev-files: true
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -119,7 +119,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.lock') }}
+          key: cargo-release-${{ runner.os }}-pg${{ matrix.version }}-${{ hashFiles('./Cargo.toml') }}
           restore-keys: cargo-release-${{ runner.os }}-pg${{ matrix.version }}
       - name: Prepare
         run: |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ mod postgres;
 mod prelude;
 
 pgrx::pg_module_magic!();
-
 pgrx::extension_sql_file!("./sql/bootstrap.sql", bootstrap);
 pgrx::extension_sql_file!("./sql/finalize.sql", finalize);
 


### PR DESCRIPTION
Update:
- complete e2e test ci
- add github cache to avoid installing `pgrx` and `sqllogictest`.
- add `sccache` to share cache for each compilation of rust code. We don't use github cache directly because incremental compilation of rust will make the cache dir becoming larger and lager.