### PR TITLE
feat: support concurrent index building

### DIFF
--- a/src/bgworker/filter_delete.rs
+++ b/src/bgworker/filter_delete.rs
@@ -65,4 +65,7 @@ impl FilterDelete {
             }
         }
     }
+    pub fn deleted(&self, p: Pointer) -> bool {
+        self.data.get(&p).map_or(false, |x| !x.value().1)
+    }
 }

--- a/src/ipc/packet.rs
+++ b/src/ipc/packet.rs
@@ -14,7 +14,6 @@ pub enum RpcPacket {
     },
     Delete {
         id: Id,
-        delete: Pointer,
     },
     Search {
         id: Id,
@@ -43,7 +42,7 @@ pub enum BuildPacket {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum NextPacket {
+pub enum BuildNextPacket {
     Leave {
         data: Option<(Box<[Scalar]>, Pointer)>,
     },
@@ -61,12 +60,18 @@ pub enum CheckPacket {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum InsertPacket {
+pub enum DeletePacket {
+    Next { p: Pointer },
     Leave {},
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum DeletePacket {
+pub enum DeleteNextPacket {
+    Leave { delete: bool },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum InsertPacket {
     Leave {},
 }
 

--- a/tests/sqllogictest/operator.slt
+++ b/tests/sqllogictest/operator.slt
@@ -60,6 +60,6 @@ SELECT '[1,2]'::vector <#> '[3,4]';
 -11
 
 query I
-SELECT '[1,2]'::vector <=> '[3,4]';
+SELECT '[1,2]'::vector <=> '[3,4]' > -1;
 ----
--0.98386997
+t

--- a/tests/sqllogictest/update.slt
+++ b/tests/sqllogictest/update.slt
@@ -1,0 +1,41 @@
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+CREATE TABLE t (val vector(3));
+
+statement ok
+INSERT INTO t (val) SELECT ARRAY[random(), random(), random()]::real[] FROM generate_series(1, 1000);
+
+statement ok
+CREATE INDEX CONCURRENTLY ON t USING vectors (val l2_ops)
+WITH (options = $$
+capacity = 2000
+[algorithm.hnsw]
+$$);
+
+statement ok
+UPDATE t SET val = ARRAY[0.2, random(), random()]::real[] WHERE val = (SELECT val FROM t ORDER BY val <-> '[0.1,0.1,0.1]' LIMIT 1);
+
+statement ok
+INSERT INTO t (val) VALUES ('[0.1,0.1,0.1]');
+
+query I
+SELECT val = '[0.1,0.1,0.1]' FROM t ORDER BY val <-> '[0.1,0.1,0.1]' LIMIT 2;
+----
+t
+f
+
+statement ok
+REINDEX TABLE CONCURRENTLY t;
+
+statement ok
+DELETE FROM t WHERE val = '[0.1,0.1,0.1]';
+
+query I
+SELECT val = '[0.1,0.1,0.1]' FROM t ORDER BY val <-> '[0.1,0.1,0.1]' LIMIT 1;
+----
+f
+
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
Update:
- update `ambuild` to return build result
- update `ambulkdelete` to support general callback function
- update delete rpc to scan for all existing vector keys and call the callback function
- add tests for `CREATE INDEX CONCURRENTLY`, `REINDEX CONCURRENTLY`, `UPDATE`, `DELETE`
- add log info in rpc handle

Close #72