### PR TITLE
chore: replace '<->' with '<*>' for L2 operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ VALUES (ARRAY[1, 2, 3]::real[]), (ARRAY[4, 5, 6]::real[]);
 
 We support three operators to calculate the distance between two vectors.
 
-- `<->`: squared Euclidean distance, defined as $\Sigma (x_i - y_i) ^ 2$.
+- `<*>`: squared Euclidean distance, defined as $\Sigma (x_i - y_i) ^ 2$.
 - `<#>`: negative dot product distance, defined as $- \Sigma x_iy_i$.
 - `<=>`: negative cosine distance, defined as $- \frac{\Sigma x_iy_i}{\sqrt{\Sigma x_i^2 \Sigma y_i^2}}$.
 
@@ -89,10 +89,10 @@ We support three operators to calculate the distance between two vectors.
 -- call the distance function through operators
 
 -- squared Euclidean distance
-SELECT '[1, 2, 3]'::vector <-> '[3, 2, 1]'::vector;
+SELECT '[1, 2, 3]' <*> '[3, 2, 1]';
 -- negative dot product distance
 SELECT '[1, 2, 3]' <#> '[3, 2, 1]';
--- negative square cosine distance
+-- negative cosine distance
 SELECT '[1, 2, 3]' <=> '[3, 2, 1]';
 ```
 
@@ -100,9 +100,9 @@ You can search for a vector simply like this.
 
 ```sql
 -- query the similar embeddings
-SELECT * FROM items ORDER BY embedding <-> '[3,2,1]' LIMIT 5;
+SELECT * FROM items ORDER BY embedding <*> '[3,2,1]' LIMIT 5;
 -- query the neighbors within a certain distance
-SELECT * FROM items WHERE embedding <-> '[3,2,1]' < 5;
+SELECT * FROM items WHERE embedding <*> '[3,2,1]' < 5;
 ```
 
 ### Indexing
@@ -141,9 +141,9 @@ $$);
 Now you can perform a KNN search with the following SQL simply.
 
 ```sql
-SELECT *, embedding <-> '[0, 0, 0]' AS score
+SELECT *, embedding <*> '[0, 0, 0]' AS score
 FROM items
-ORDER BY embedding <-> '[0, 0, 0]' LIMIT 10;
+ORDER BY embedding <*> '[0, 0, 0]' LIMIT 10;
 ```
 
 We planning to support more index types ([issue here](https://github.com/tensorchord/pgvecto.rs/issues/17)).
@@ -254,7 +254,7 @@ If you want to disable vector indexing or prefilter, we also offer some GUC opti
 
 ## Limitations
 
-- The filtering process is not yet optimized. To achieve optimal performance, you may need to manually experiment with different strategies. For example, you can try searching without a vector index or implementing post-filtering techniques like the following query: `select * from (select * from items ORDER BY embedding <-> '[3,2,1]' LIMIT 100 ) where category = 1`. This involves using approximate nearest neighbor (ANN) search to obtain enough results and then applying filtering afterwards.
+- The filtering process is not yet optimized. To achieve optimal performance, you may need to manually experiment with different strategies. For example, you can try searching without a vector index or implementing post-filtering techniques like the following query: `select * from (select * from items ORDER BY embedding <*> '[3,2,1]' LIMIT 100 ) where category = 1`. This involves using approximate nearest neighbor (ANN) search to obtain enough results and then applying filtering afterwards.
 
 ## Setting up the development environment
 

--- a/bindings/python/examples/psycopg_example.py
+++ b/bindings/python/examples/psycopg_example.py
@@ -44,7 +44,7 @@ with psycopg.connect(URL) as conn:
         # Select all the rows and sort them
         # by the squared_euclidean_distance to "hello pgvecto.rs"
         cur = conn.execute(
-            "SELECT text, embedding <-> %s AS distance FROM documents ORDER BY distance;",
+            "SELECT text, embedding <*> %s AS distance FROM documents ORDER BY distance;",
             (target,),
         )
         for row in cur.fetchall():

--- a/bindings/python/src/pgvecto_rs/sqlalchemy/__init__.py
+++ b/bindings/python/src/pgvecto_rs/sqlalchemy/__init__.py
@@ -29,7 +29,7 @@ class Vector(types.UserDefinedType):
 
     class comparator_factory(types.UserDefinedType.Comparator):
         def squared_euclidean_distance(self, other):
-            return self.op("<->", return_type=types.Float)(other)
+            return self.op("<*>", return_type=types.Float)(other)
 
         def negative_dot_product_distance(self, other):
             return self.op("<#>", return_type=types.Float)(other)

--- a/bindings/python/tests/test_psycopg.py
+++ b/bindings/python/tests/test_psycopg.py
@@ -79,7 +79,7 @@ def test_insert(conn: Connection):
 
 def test_squared_euclidean_distance(conn: Connection):
     cur = conn.execute(
-        "SELECT embedding <-> %s FROM tb_test_item;", (OP_SQRT_EUCLID_DIS,)
+        "SELECT embedding <*> %s FROM tb_test_item;", (OP_SQRT_EUCLID_DIS,)
     )
     for i, row in enumerate(cur.fetchall()):
         assert np.allclose(EXPECTED_SQRT_EUCLID_DIS[i], row[0], atol=1e-10)

--- a/docs/comparison-with-specialized-vectordb.md
+++ b/docs/comparison-with-specialized-vectordb.md
@@ -15,7 +15,7 @@ UPDATE documents SET embedding = ai_embedding_vector(content) WHERE length(embed
 CREATE INDEX ON documents USING vectors (embedding l2_ops);
 
 -- Query the similar embeddings
-SELECT * FROM documents ORDER BY embedding <-> ai_embedding_vector('hello world') LIMIT 5;
+SELECT * FROM documents ORDER BY embedding <*> ai_embedding_vector('hello world') LIMIT 5;
 ```
 
 From [SingleStore DB Blog](https://www.singlestore.com/blog/why-your-vector-database-should-not-be-a-vector-database/):

--- a/src/postgres/index_setup.rs
+++ b/src/postgres/index_setup.rs
@@ -53,7 +53,7 @@ pub unsafe fn convert_opfamily_to_distance(opfamily: pgrx::pg_sys::Oid) -> Dista
     assert!((*amop).amoppurpose == pgrx::pg_sys::AMOP_ORDER as i8);
     let operator = (*amop).amopopr;
     let distance;
-    if operator == regoperatorin("<->(vector,vector)") {
+    if operator == regoperatorin("<*>(vector,vector)") {
         distance = Distance::L2;
     } else if operator == regoperatorin("<#>(vector,vector)") {
         distance = Distance::Dot;

--- a/src/postgres/operators.rs
+++ b/src/postgres/operators.rs
@@ -110,8 +110,8 @@ fn operator_dot(lhs: VectorInput<'_>, rhs: VectorInput<'_>) -> Scalar {
 }
 
 #[pgrx::pg_operator(immutable, parallel_safe, requires = ["vector"])]
-#[pgrx::opname(<->)]
-#[pgrx::commutator(<->)]
+#[pgrx::opname(<*>)]
+#[pgrx::commutator(<*>)]
 fn operator_l2(lhs: VectorInput<'_>, rhs: VectorInput<'_>) -> Scalar {
     assert_eq!(lhs.len(), rhs.len(), "Invaild operation.");
     Distance::L2.distance(&lhs, &rhs)

--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -6,7 +6,7 @@ CREATE CAST (vector AS real[])
 
 CREATE OPERATOR CLASS l2_ops
 	FOR TYPE vector USING vectors AS
-	OPERATOR 1 <-> (vector, vector) FOR ORDER BY float_ops;
+	OPERATOR 1 <*> (vector, vector) FOR ORDER BY float_ops;
 
 CREATE OPERATOR CLASS dot_ops
 	FOR TYPE vector USING vectors AS

--- a/tests/sqllogictest/error.slt
+++ b/tests/sqllogictest/error.slt
@@ -11,4 +11,4 @@ statement error The given vector is invalid for input.
 INSERT INTO t (val) VALUES ('[0, 1, 2, 3]');
 
 statement error The given vector is invalid for input.
-SELECT * FROM t ORDER BY val <-> '[0, 1, 2, 3]';
+SELECT * FROM t ORDER BY val <*> '[0, 1, 2, 3]';

--- a/tests/sqllogictest/flat.slt
+++ b/tests/sqllogictest/flat.slt
@@ -15,7 +15,7 @@ statement ok
 INSERT INTO t (val) VALUES ('[0.6,0.6,0.6]');
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <*> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 

--- a/tests/sqllogictest/hnsw.slt
+++ b/tests/sqllogictest/hnsw.slt
@@ -18,7 +18,7 @@ statement ok
 INSERT INTO t (val) VALUES ('[0.6,0.6,0.6]');
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <*> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 

--- a/tests/sqllogictest/ivf.slt
+++ b/tests/sqllogictest/ivf.slt
@@ -19,7 +19,7 @@ statement ok
 INSERT INTO t (val) VALUES ('[0.6,0.6,0.6]');
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <*> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 
@@ -54,7 +54,7 @@ statement ok
 INSERT INTO t (val) VALUES ('[0.6,0.6,0.6]');
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <*> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 

--- a/tests/sqllogictest/operator.slt
+++ b/tests/sqllogictest/operator.slt
@@ -48,9 +48,9 @@ SELECT '[1,2]'::vector >= '[2,2]';
 ----
 f
 
-# basic <->(squared Euclidean distance) <#>(negative dot product distance) <=>(negative cosine distance)
+# basic <*>(squared Euclidean distance) <#>(negative dot product distance) <=>(negative cosine distance)
 query I
-SELECT '[1,2]'::vector <-> '[3,4]';
+SELECT '[1,2]'::vector <*> '[3,4]';
 ----
 8
 

--- a/tests/sqllogictest/quantization.slt
+++ b/tests/sqllogictest/quantization.slt
@@ -16,7 +16,7 @@ statement ok
 INSERT INTO t (val) VALUES ('[0.6,0.6,0.6]');
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <*> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 
@@ -48,7 +48,7 @@ statement ok
 INSERT INTO t (val) VALUES ('[0.6,0.6,0.6]');
 
 query I
-SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <*> '[0.5,0.5,0.5]' limit 10) t2;
 ----
 10
 

--- a/tests/sqllogictest/update.slt
+++ b/tests/sqllogictest/update.slt
@@ -11,13 +11,13 @@ statement ok
 CREATE INDEX CONCURRENTLY ON t USING vectors (val l2_ops);
 
 statement ok
-UPDATE t SET val = ARRAY[0.2, random(), random()]::real[] WHERE val = (SELECT val FROM t ORDER BY val <-> '[0.1,0.1,0.1]' LIMIT 1);
+UPDATE t SET val = ARRAY[0.2, random(), random()]::real[] WHERE val = (SELECT val FROM t ORDER BY val <*> '[0.1,0.1,0.1]' LIMIT 1);
 
 statement ok
 INSERT INTO t (val) VALUES ('[0.1,0.1,0.1]');
 
 query I
-SELECT val = '[0.1,0.1,0.1]' FROM t ORDER BY val <-> '[0.1,0.1,0.1]' LIMIT 2;
+SELECT val = '[0.1,0.1,0.1]' FROM t ORDER BY val <*> '[0.1,0.1,0.1]' LIMIT 2;
 ----
 t
 f
@@ -29,7 +29,7 @@ statement ok
 DELETE FROM t WHERE val = '[0.1,0.1,0.1]';
 
 query I
-SELECT val = '[0.1,0.1,0.1]' FROM t ORDER BY val <-> '[0.1,0.1,0.1]' LIMIT 1;
+SELECT val = '[0.1,0.1,0.1]' FROM t ORDER BY val <*> '[0.1,0.1,0.1]' LIMIT 1;
 ----
 f
 


### PR DESCRIPTION
`<->` is overloaded by PostgreSQL's text search facility. [^1]

We should use another operator name to escape potential problems.

related: #108 

[^1]: https://www.postgresql.org/docs/current/functions-textsearch.html