### PR TITLE
feat: add nprobe into guc

### DIFF
--- a/crates/service/src/algorithms/ivf/ivf_naive.rs
+++ b/crates/service/src/algorithms/ivf/ivf_naive.rs
@@ -55,8 +55,14 @@ impl<S: G> IvfNaive<S> {
         self.mmap.raw.payload(i)
     }
 
-    pub fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap {
-        search(&self.mmap, k, vector, filter)
+    pub fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        nprobe: u32,
+        filter: &mut impl Filter,
+    ) -> Heap {
+        search(&self.mmap, k, vector, nprobe, filter)
     }
 }
 
@@ -70,7 +76,6 @@ pub struct IvfRam<S: G> {
     dims: u16,
     // ----------------------
     nlist: u32,
-    nprobe: u32,
     // ----------------------
     centroids: Vec2<S>,
     heads: Vec<AtomicU32>,
@@ -87,7 +92,6 @@ pub struct IvfMmap<S: G> {
     dims: u16,
     // ----------------------
     nlist: u32,
-    nprobe: u32,
     // ----------------------
     centroids: MmapArray<S::Scalar>,
     heads: MmapArray<u32>,
@@ -116,7 +120,6 @@ pub fn make<S: G>(
         least_iterations,
         iterations,
         nlist,
-        nprobe,
         nsample,
         quantization: quantization_opts,
     } = options.indexing.clone().unwrap_ivf();
@@ -186,7 +189,6 @@ pub fn make<S: G>(
         centroids,
         heads,
         nexts,
-        nprobe,
         nlist,
         dims,
     }
@@ -212,7 +214,6 @@ pub fn save<S: G>(mut ram: IvfRam<S>, path: PathBuf) -> IvfMmap<S> {
         quantization: ram.quantization,
         dims: ram.dims,
         nlist: ram.nlist,
-        nprobe: ram.nprobe,
         centroids,
         heads,
         nexts,
@@ -230,13 +231,12 @@ pub fn load<S: G>(path: PathBuf, options: IndexOptions) -> IvfMmap<S> {
     let centroids = MmapArray::open(path.join("centroids"));
     let heads = MmapArray::open(path.join("heads"));
     let nexts = MmapArray::open(path.join("nexts"));
-    let IvfIndexingOptions { nlist, nprobe, .. } = options.indexing.unwrap_ivf();
+    let IvfIndexingOptions { nlist, .. } = options.indexing.unwrap_ivf();
     IvfMmap {
         raw,
         quantization,
         dims: options.vector.dims,
         nlist,
-        nprobe,
         centroids,
         heads,
         nexts,
@@ -247,11 +247,12 @@ pub fn search<S: G>(
     mmap: &IvfMmap<S>,
     k: usize,
     vector: &[S::Scalar],
+    nprobe: u32,
     filter: &mut impl Filter,
 ) -> Heap {
     let mut target = vector.to_vec();
     S::elkan_k_means_normalize(&mut target);
-    let mut lists = Heap::new(mmap.nprobe as usize);
+    let mut lists = Heap::new(nprobe as usize);
     for i in 0..mmap.nlist {
         let centroid = mmap.centroids(i);
         let distance = S::elkan_k_means_distance(&target, centroid);

--- a/crates/service/src/algorithms/ivf/mod.rs
+++ b/crates/service/src/algorithms/ivf/mod.rs
@@ -70,10 +70,16 @@ impl<S: G> Ivf<S> {
         }
     }
 
-    pub fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap {
+    pub fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        nprobe: u32,
+        filter: &mut impl Filter,
+    ) -> Heap {
         match self {
-            Ivf::Naive(x) => x.search(k, vector, filter),
-            Ivf::Pq(x) => x.search(k, vector, filter),
+            Ivf::Naive(x) => x.search(k, vector, nprobe, filter),
+            Ivf::Pq(x) => x.search(k, vector, nprobe, filter),
         }
     }
 }

--- a/crates/service/src/index/indexing/flat.rs
+++ b/crates/service/src/index/indexing/flat.rs
@@ -1,6 +1,7 @@
 use super::AbstractIndexing;
 use crate::algorithms::quantization::QuantizationOptions;
 use crate::index::segments::growing::GrowingSegment;
+use crate::index::segments::sealed::SealedSearchGucs;
 use crate::index::IndexOptions;
 use crate::prelude::*;
 use crate::{algorithms::flat::Flat, index::segments::sealed::SealedSegment};
@@ -57,7 +58,13 @@ impl<S: G> AbstractIndexing<S> for FlatIndexing<S> {
         self.raw.payload(i)
     }
 
-    fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap {
+    fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        _gucs: SealedSearchGucs,
+        filter: &mut impl Filter,
+    ) -> Heap {
         self.raw.search(k, vector, filter)
     }
 }

--- a/crates/service/src/index/indexing/hnsw.rs
+++ b/crates/service/src/index/indexing/hnsw.rs
@@ -2,6 +2,7 @@ use super::AbstractIndexing;
 use crate::algorithms::hnsw::HnswIndexIter;
 use crate::algorithms::quantization::QuantizationOptions;
 use crate::index::segments::growing::GrowingSegment;
+use crate::index::segments::sealed::SealedSearchGucs;
 use crate::index::IndexOptions;
 use crate::prelude::*;
 use crate::{algorithms::hnsw::Hnsw, index::segments::sealed::SealedSegment};
@@ -74,7 +75,13 @@ impl<S: G> AbstractIndexing<S> for HnswIndexing<S> {
         self.raw.payload(i)
     }
 
-    fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap {
+    fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        _gucs: SealedSearchGucs,
+        filter: &mut impl Filter,
+    ) -> Heap {
         self.raw.search(k, vector, filter)
     }
 }

--- a/crates/service/src/index/indexing/ivf.rs
+++ b/crates/service/src/index/indexing/ivf.rs
@@ -2,6 +2,7 @@ use super::AbstractIndexing;
 use crate::algorithms::ivf::Ivf;
 use crate::algorithms::quantization::QuantizationOptions;
 use crate::index::segments::growing::GrowingSegment;
+use crate::index::segments::sealed::SealedSearchGucs;
 use crate::index::segments::sealed::SealedSegment;
 use crate::index::IndexOptions;
 use crate::prelude::*;
@@ -22,9 +23,6 @@ pub struct IvfIndexingOptions {
     #[serde(default = "IvfIndexingOptions::default_nlist")]
     #[validate(range(min = 1, max = 1_000_000))]
     pub nlist: u32,
-    #[serde(default = "IvfIndexingOptions::default_nprobe")]
-    #[validate(range(min = 1, max = 1_000_000))]
-    pub nprobe: u32,
     #[serde(default = "IvfIndexingOptions::default_nsample")]
     #[validate(range(min = 1, max = 1_000_000))]
     pub nsample: u32,
@@ -43,9 +41,6 @@ impl IvfIndexingOptions {
     fn default_nlist() -> u32 {
         1000
     }
-    fn default_nprobe() -> u32 {
-        10
-    }
     fn default_nsample() -> u32 {
         65536
     }
@@ -57,7 +52,6 @@ impl Default for IvfIndexingOptions {
             least_iterations: Self::default_least_iterations(),
             iterations: Self::default_iterations(),
             nlist: Self::default_nlist(),
-            nprobe: Self::default_nprobe(),
             nsample: Self::default_nsample(),
             quantization: Default::default(),
         }
@@ -96,7 +90,13 @@ impl<S: G> AbstractIndexing<S> for IvfIndexing<S> {
         self.raw.payload(i)
     }
 
-    fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap {
-        self.raw.search(k, vector, filter)
+    fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        gucs: SealedSearchGucs,
+        filter: &mut impl Filter,
+    ) -> Heap {
+        self.raw.search(k, vector, gucs.ivf_nprob, filter)
     }
 }

--- a/crates/service/src/index/indexing/mod.rs
+++ b/crates/service/src/index/indexing/mod.rs
@@ -9,6 +9,7 @@ use super::segments::growing::GrowingSegment;
 use super::segments::sealed::SealedSegment;
 use super::IndexOptions;
 use crate::algorithms::hnsw::HnswIndexIter;
+use crate::index::segments::sealed::SealedSearchGucs;
 use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -72,7 +73,13 @@ pub trait AbstractIndexing<S: G>: Sized {
     fn len(&self) -> u32;
     fn vector(&self, i: u32) -> &[S::Scalar];
     fn payload(&self, i: u32) -> Payload;
-    fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap;
+    fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        gucs: SealedSearchGucs,
+        filter: &mut impl Filter,
+    ) -> Heap;
 }
 
 pub enum DynamicIndexing<S: G> {
@@ -137,11 +144,17 @@ impl<S: G> DynamicIndexing<S> {
         }
     }
 
-    pub fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap {
+    pub fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        gucs: SealedSearchGucs,
+        filter: &mut impl Filter,
+    ) -> Heap {
         match self {
-            DynamicIndexing::Flat(x) => x.search(k, vector, filter),
-            DynamicIndexing::Ivf(x) => x.search(k, vector, filter),
-            DynamicIndexing::Hnsw(x) => x.search(k, vector, filter),
+            DynamicIndexing::Flat(x) => x.search(k, vector, gucs, filter),
+            DynamicIndexing::Ivf(x) => x.search(k, vector, gucs, filter),
+            DynamicIndexing::Hnsw(x) => x.search(k, vector, gucs, filter),
         }
     }
 

--- a/crates/service/src/index/mod.rs
+++ b/crates/service/src/index/mod.rs
@@ -13,6 +13,7 @@ use self::segments::SegmentsOptions;
 use crate::index::indexing::DynamicIndexIter;
 use crate::index::optimizing::indexing::OptimizerIndexing;
 use crate::index::optimizing::sealing::OptimizerSealing;
+use crate::index::segments::SearchGucs;
 use crate::prelude::*;
 use crate::utils::clean::clean;
 use crate::utils::dir_ops::sync_dir;
@@ -270,6 +271,7 @@ impl<S: G> IndexView<S> {
         &self,
         k: usize,
         vector: &[S::Scalar],
+        gucs: SearchGucs,
         mut filter: F,
     ) -> Vec<Pointer> {
         assert_eq!(self.options.vector.dims as usize, vector.len());
@@ -307,7 +309,9 @@ impl<S: G> IndexView<S> {
         let mut result = Heap::new(k);
         let mut heaps = BinaryHeap::with_capacity(1 + n);
         for (_, sealed) in self.sealed.iter() {
-            let p = sealed.search(k, vector, &mut filter).into_reversed_heap();
+            let p = sealed
+                .search(k, vector, gucs.sealed, &mut filter)
+                .into_reversed_heap();
             heaps.push(Comparer(p));
         }
         for (_, growing) in self.growing.iter() {

--- a/crates/service/src/index/segments/mod.rs
+++ b/crates/service/src/index/segments/mod.rs
@@ -2,11 +2,17 @@ pub mod growing;
 pub mod sealed;
 
 use super::IndexTracker;
+use crate::index::segments::sealed::SealedSearchGucs;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use validator::Validate;
 use validator::ValidationError;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Validate)]
+pub struct SearchGucs {
+    pub sealed: SealedSearchGucs,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 #[serde(deny_unknown_fields)]

--- a/crates/service/src/index/segments/sealed.rs
+++ b/crates/service/src/index/segments/sealed.rs
@@ -4,9 +4,16 @@ use crate::index::indexing::{DynamicIndexIter, DynamicIndexing};
 use crate::index::{IndexOptions, IndexTracker};
 use crate::prelude::*;
 use crate::utils::dir_ops::sync_dir;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
+use validator::Validate;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Validate)]
+pub struct SealedSearchGucs {
+    pub ivf_nprob: u32,
+}
 
 pub struct SealedSegment<S: G> {
     uuid: Uuid,
@@ -57,8 +64,14 @@ impl<S: G> SealedSegment<S> {
     pub fn payload(&self, i: u32) -> Payload {
         self.indexing.payload(i)
     }
-    pub fn search(&self, k: usize, vector: &[S::Scalar], filter: &mut impl Filter) -> Heap {
-        self.indexing.search(k, vector, filter)
+    pub fn search(
+        &self,
+        k: usize,
+        vector: &[S::Scalar],
+        gucs: SealedSearchGucs,
+        filter: &mut impl Filter,
+    ) -> Heap {
+        self.indexing.search(k, vector, gucs, filter)
     }
     pub fn vbase(&self, range: usize, vector: &[S::Scalar]) -> DynamicIndexIter<'_, S> {
         self.indexing.vbase(range, vector)

--- a/crates/service/src/worker/instance.rs
+++ b/crates/service/src/worker/instance.rs
@@ -1,3 +1,4 @@
+use crate::index::segments::SearchGucs;
 use crate::index::Index;
 use crate::index::IndexOptions;
 use crate::index::IndexStat;
@@ -94,6 +95,7 @@ impl InstanceView {
         &self,
         k: usize,
         vector: DynamicVector,
+        gucs: SearchGucs,
         filter: F,
     ) -> Result<Vec<Pointer>, FriendlyError> {
         match (self, vector) {
@@ -101,37 +103,37 @@ impl InstanceView {
                 if x.options.vector.dims as usize != vector.len() {
                     return Err(FriendlyError::Unmatched2);
                 }
-                Ok(x.search(k, &vector, filter))
+                Ok(x.search(k, &vector, gucs, filter))
             }
             (InstanceView::F32Dot(x), DynamicVector::F32(vector)) => {
                 if x.options.vector.dims as usize != vector.len() {
                     return Err(FriendlyError::Unmatched2);
                 }
-                Ok(x.search(k, &vector, filter))
+                Ok(x.search(k, &vector, gucs, filter))
             }
             (InstanceView::F32L2(x), DynamicVector::F32(vector)) => {
                 if x.options.vector.dims as usize != vector.len() {
                     return Err(FriendlyError::Unmatched2);
                 }
-                Ok(x.search(k, &vector, filter))
+                Ok(x.search(k, &vector, gucs, filter))
             }
             (InstanceView::F16Cos(x), DynamicVector::F16(vector)) => {
                 if x.options.vector.dims as usize != vector.len() {
                     return Err(FriendlyError::Unmatched2);
                 }
-                Ok(x.search(k, &vector, filter))
+                Ok(x.search(k, &vector, gucs, filter))
             }
             (InstanceView::F16Dot(x), DynamicVector::F16(vector)) => {
                 if x.options.vector.dims as usize != vector.len() {
                     return Err(FriendlyError::Unmatched2);
                 }
-                Ok(x.search(k, &vector, filter))
+                Ok(x.search(k, &vector, gucs, filter))
             }
             (InstanceView::F16L2(x), DynamicVector::F16(vector)) => {
                 if x.options.vector.dims as usize != vector.len() {
                     return Err(FriendlyError::Unmatched2);
                 }
-                Ok(x.search(k, &vector, filter))
+                Ok(x.search(k, &vector, gucs, filter))
             }
             _ => Err(FriendlyError::Unmatched2),
         }

--- a/crates/service/src/worker/mod.rs
+++ b/crates/service/src/worker/mod.rs
@@ -2,6 +2,7 @@ pub mod instance;
 pub mod metadata;
 
 use self::instance::Instance;
+use crate::index::segments::SearchGucs;
 use crate::index::IndexOptions;
 use crate::index::IndexStat;
 use crate::index::OutdatedError;
@@ -78,6 +79,7 @@ impl Worker {
         &self,
         id: Id,
         search: (DynamicVector, usize),
+        gucs: SearchGucs,
         filter: F,
     ) -> Result<Vec<Pointer>, FriendlyError>
     where
@@ -86,7 +88,7 @@ impl Worker {
         let view = self.view.load_full();
         let index = view.indexes.get(&id).ok_or(FriendlyError::UnknownIndex)?;
         let view = index.view();
-        view.search(search.1, search.0, filter)
+        view.search(search.1, search.0, gucs, filter)
     }
     pub fn call_insert(
         &self,

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -75,7 +75,6 @@ Options for table `ivf`.
 | Key              | Type    | Description                                                     |
 | ---------------- | ------- | --------------------------------------------------------------- |
 | nlist            | integer | Number of cluster units. Default value is `1000`.               |
-| nprobe           | integer | Number of units to query. Default value is `10`.                |
 | least_iterations | integer | Least iterations for K-Means clustering. Default value is `16`. |
 | iterations       | integer | Max iterations for K-Means clustering. Default value is `500`.  |
 | quantization     | table   | The quantization algorithm to be used.                          |

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -29,6 +29,7 @@ Search options are specified by PostgreSQL GUC. You can use `SET` command to app
 | Option                      | Type    | Description                                                                                                                                                   |
 | --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | vectors.k                   | integer | Expected number of candidates returned by index. The parameter will influence the recall if you use HNSW or quantization for indexing. Default value is `64`. |
+| vectors.ivf_nprobe          | integer | Number of units to query for ivf index. Default value is `10`.  |
 | vectors.enable_prefilter    | boolean | Enable prefiltering or not. Default value is `off`.                                                                                                           |
 | vectors.enable_vector_index | boolean | Enable vector indexes or not. This option is for debugging. Default value is `on`.                                                                            |
 | vectors.enable_vbase        | boolean | Enable vbase optimization or not. Default value is `off`.                                                                                                     |

--- a/src/bgworker/normal.rs
+++ b/src/bgworker/normal.rs
@@ -77,8 +77,9 @@ fn session(worker: Arc<Worker>, mut handler: RpcHandler) -> Result<(), IpcError>
                 id,
                 search,
                 prefilter: true,
+                gucs,
                 mut x,
-            } => match worker.call_search(id, search, |p| x.check(p).unwrap()) {
+            } => match worker.call_search(id, search, gucs, |p| x.check(p).unwrap()) {
                 Ok(res) => handler = x.leave(res)?,
                 Err(e) => x.reset(e)?,
             },
@@ -86,8 +87,9 @@ fn session(worker: Arc<Worker>, mut handler: RpcHandler) -> Result<(), IpcError>
                 id,
                 search,
                 prefilter: false,
+                gucs,
                 x,
-            } => match worker.call_search(id, search, |_| true) {
+            } => match worker.call_search(id, search, gucs, |_| true) {
                 Ok(res) => handler = x.leave(res)?,
                 Err(e) => x.reset(e)?,
             },

--- a/src/gucs.rs
+++ b/src/gucs.rs
@@ -19,6 +19,8 @@ pub static OPENAI_API_KEY_GUC: GucSetting<Option<&'static CStr>> =
 
 pub static K: GucSetting<i32> = GucSetting::<i32>::new(64);
 
+pub static IVF_NPROBE: GucSetting<i32> = GucSetting::<i32>::new(10);
+
 pub static ENABLE_VECTOR_INDEX: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 pub static ENABLE_PREFILTER: GucSetting<bool> = GucSetting::<bool>::new(false);
@@ -45,6 +47,16 @@ pub unsafe fn init() {
         &K,
         1,
         u16::MAX as _,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        "vectors.ivf_nporbe",
+        "The number of probes at ivf index.",
+        "The number of probes at ivf index.",
+        &IVF_NPROBE,
+        1,
+        1_000_000,
         GucContext::Userset,
         GucFlags::default(),
     );

--- a/src/ipc/client/mod.rs
+++ b/src/ipc/client/mod.rs
@@ -2,6 +2,7 @@ use super::packet::*;
 use super::transport::ClientSocket;
 use crate::gucs::{Transport, TRANSPORT};
 use crate::utils::cells::PgRefCell;
+use service::index::segments::SearchGucs;
 use service::index::IndexOptions;
 use service::index::IndexStat;
 use service::prelude::*;
@@ -60,12 +61,14 @@ impl Rpc {
         id: Id,
         search: (DynamicVector, usize),
         prefilter: bool,
+        gucs: SearchGucs,
         mut t: impl Search,
     ) -> Vec<Pointer> {
         let packet = RpcPacket::Search {
             id,
             search,
             prefilter,
+            gucs,
         };
         self.socket.send(packet).friendly();
         loop {

--- a/src/ipc/packet/mod.rs
+++ b/src/ipc/packet/mod.rs
@@ -8,6 +8,7 @@ pub mod stat;
 pub mod vbase;
 
 use serde::{Deserialize, Serialize};
+use service::index::segments::SearchGucs;
 use service::index::IndexOptions;
 use service::prelude::*;
 
@@ -34,6 +35,7 @@ pub enum RpcPacket {
         id: Id,
         search: (DynamicVector, usize),
         prefilter: bool,
+        gucs: SearchGucs,
     },
     Stat {
         id: Id,

--- a/src/ipc/server/mod.rs
+++ b/src/ipc/server/mod.rs
@@ -1,6 +1,7 @@
 use super::packet::*;
 use super::transport::ServerSocket;
 use super::IpcError;
+use service::index::segments::SearchGucs;
 use service::index::IndexOptions;
 use service::index::IndexStat;
 use service::prelude::*;
@@ -39,10 +40,12 @@ impl RpcHandler {
                 id,
                 search,
                 prefilter,
+                gucs,
             } => RpcHandle::Search {
                 id,
                 search,
                 prefilter,
+                gucs,
                 x: Search {
                     socket: self.socket,
                 },
@@ -86,6 +89,7 @@ pub enum RpcHandle {
         id: Id,
         search: (DynamicVector, usize),
         prefilter: bool,
+        gucs: SearchGucs,
         x: Search,
     },
     Insert {


### PR DESCRIPTION
Fix #194 

# Design
It's a bad idea to straightly pass parameter `nprobe` to all indexes, as only `ivf` need it.
However, for `ipc` caller `am_scan`, it's transparent of index type in use, as it is parsed at callee `service`, so we could not construct an union before `am_scan`.

Thus, we create a dataclass `SearchGucs` which could handle runtime variables for both `sealed` and `growing` segments.
And `SealedSearchGucs` which contains `ivf_probe` and other future required runtime variables, it could handle all runtime variables for sealed indexes, thus approprate to pass to all indexes.

If there is other idea for the design, I would be happy to know.

# Feat
- Introduce `SearchGucs` for gucs accessed by `search` method
- Introduce `SealedSearchGucs` for gucs accessed by `sealed segments search` method
- `ivf` would handle `SealedSearchGucs.ivf_nprobe` while `HNSW` and `flat` not, leaving a private argument `_gucs`