### PR TITLE
feat: show index size in index info table

### DIFF
--- a/crates/service/src/index/mod.rs
+++ b/crates/service/src/index/mod.rs
@@ -69,6 +69,7 @@ pub struct IndexStat {
     pub growing: Vec<u32>,
     pub write: u32,
     pub options: IndexOptions,
+    pub size: u64,
 }
 
 pub struct Index<S: G> {
@@ -239,6 +240,8 @@ impl<S: G> Index<S> {
             growing: view.growing.values().map(|x| x.len()).collect(),
             write: view.write.as_ref().map(|(_, x)| x.len()).unwrap_or(0),
             options: self.options().clone(),
+            size: view.growing.values().map(|x| x.size() as u64).sum::<u64>()
+                + view.sealed.values().map(|x| x.size() as u64).sum::<u64>(),
         }
     }
 }

--- a/crates/service/src/index/mod.rs
+++ b/crates/service/src/index/mod.rs
@@ -63,13 +63,23 @@ pub struct IndexOptions {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SegmentSizeInfo {
+    pub id: Uuid,
+    #[serde(rename = "type")]
+    pub typ: String,
+    pub length: usize,
+    pub size: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct IndexStat {
     pub indexing: bool,
     pub sealed: Vec<u32>,
     pub growing: Vec<u32>,
     pub write: u32,
     pub options: IndexOptions,
-    pub size: u64,
+    pub size: Vec<SegmentSizeInfo>,
 }
 
 pub struct Index<S: G> {
@@ -240,8 +250,12 @@ impl<S: G> Index<S> {
             growing: view.growing.values().map(|x| x.len()).collect(),
             write: view.write.as_ref().map(|(_, x)| x.len()).unwrap_or(0),
             options: self.options().clone(),
-            size: view.growing.values().map(|x| x.size()).sum::<u64>()
-                + view.sealed.values().map(|x| x.size()).sum::<u64>(),
+            size: view
+                .sealed
+                .values()
+                .map(|x| x.size())
+                .chain(view.growing.values().map(|x| x.size()))
+                .collect(),
         }
     }
 }

--- a/crates/service/src/index/mod.rs
+++ b/crates/service/src/index/mod.rs
@@ -79,7 +79,7 @@ pub struct IndexStat {
     pub growing: Vec<u32>,
     pub write: u32,
     pub options: IndexOptions,
-    pub size: Vec<SegmentSizeInfo>,
+    pub sizes: Vec<SegmentSizeInfo>,
 }
 
 pub struct Index<S: G> {
@@ -250,7 +250,7 @@ impl<S: G> Index<S> {
             growing: view.growing.values().map(|x| x.len()).collect(),
             write: view.write.as_ref().map(|(_, x)| x.len()).unwrap_or(0),
             options: self.options().clone(),
-            size: view
+            sizes: view
                 .sealed
                 .values()
                 .map(|x| x.size())

--- a/crates/service/src/index/mod.rs
+++ b/crates/service/src/index/mod.rs
@@ -240,8 +240,8 @@ impl<S: G> Index<S> {
             growing: view.growing.values().map(|x| x.len()).collect(),
             write: view.write.as_ref().map(|(_, x)| x.len()).unwrap_or(0),
             options: self.options().clone(),
-            size: view.growing.values().map(|x| x.size() as u64).sum::<u64>()
-                + view.sealed.values().map(|x| x.size() as u64).sum::<u64>(),
+            size: view.growing.values().map(|x| x.size()).sum::<u64>()
+                + view.sealed.values().map(|x| x.size()).sum::<u64>(),
         }
     }
 }

--- a/crates/service/src/index/segments/growing.rs
+++ b/crates/service/src/index/segments/growing.rs
@@ -3,6 +3,7 @@
 use super::SegmentTracker;
 use crate::index::IndexOptions;
 use crate::index::IndexTracker;
+use crate::index::SegmentSizeInfo;
 use crate::prelude::*;
 use crate::utils::dir_ops::sync_dir;
 use crate::utils::file_wal::FileWal;
@@ -140,8 +141,13 @@ impl<S: G> GrowingSegment<S> {
     pub fn len(&self) -> u32 {
         self.len.load(Ordering::Acquire) as u32
     }
-    pub fn size(&self) -> u64 {
-        (self.len() as u64) * (std::mem::size_of::<Log<S>>() as u64)
+    pub fn size(&self) -> SegmentSizeInfo {
+        SegmentSizeInfo {
+            id: self.uuid,
+            typ: "growing".to_string(),
+            length: self.len() as usize,
+            size: (self.len() as u64) * (std::mem::size_of::<Log<S>>() as u64),
+        }
     }
     pub fn vector(&self, i: u32) -> &[S::Scalar] {
         let i = i as usize;

--- a/crates/service/src/index/segments/growing.rs
+++ b/crates/service/src/index/segments/growing.rs
@@ -140,6 +140,9 @@ impl<S: G> GrowingSegment<S> {
     pub fn len(&self) -> u32 {
         self.len.load(Ordering::Acquire) as u32
     }
+    pub fn size(&self) -> u64 {
+        (self.len() as u64) * (std::mem::size_of::<Log<S>>() as u64)
+    }
     pub fn vector(&self, i: u32) -> &[S::Scalar] {
         let i = i as usize;
         if i >= self.len.load(Ordering::Acquire) {

--- a/crates/service/src/index/segments/sealed.rs
+++ b/crates/service/src/index/segments/sealed.rs
@@ -69,7 +69,7 @@ impl<S: G> SealedSegment<S> {
         match dir_size(&path) {
             Ok(size) => info.size = size as u64,
             Err(e) => {
-                log::error!("Failed to get size of {:?}: {}", path, e);
+                panic!("Failed to get size of {:?}: {}", path, e);
             }
         }
         info

--- a/crates/service/src/index/segments/sealed.rs
+++ b/crates/service/src/index/segments/sealed.rs
@@ -1,9 +1,9 @@
 use super::growing::GrowingSegment;
 use super::SegmentTracker;
 use crate::index::indexing::{DynamicIndexIter, DynamicIndexing};
-use crate::index::{IndexOptions, IndexTracker};
+use crate::index::{IndexOptions, IndexTracker, SegmentSizeInfo};
 use crate::prelude::*;
-use crate::utils::dir_ops::sync_dir;
+use crate::utils::dir_ops::{dir_size, sync_dir};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -58,9 +58,21 @@ impl<S: G> SealedSegment<S> {
     pub fn len(&self) -> u32 {
         self.indexing.len()
     }
-    pub fn size(&self) -> u64 {
-        (self.indexing.len() as u64)
-            * (std::mem::size_of::<S::Scalar>() + std::mem::size_of::<Payload>()) as u64
+    pub fn size(&self) -> SegmentSizeInfo {
+        let mut info = SegmentSizeInfo {
+            id: self.uuid,
+            typ: "sealed".to_string(),
+            length: self.len() as usize,
+            size: 0,
+        };
+        let path = self._tracker.path.join("indexing");
+        match dir_size(&path) {
+            Ok(size) => info.size = size as u64,
+            Err(e) => {
+                log::error!("Failed to get size of {:?}: {}", path, e);
+            }
+        }
+        info
     }
     pub fn vector(&self, i: u32) -> &[S::Scalar] {
         self.indexing.vector(i)

--- a/crates/service/src/index/segments/sealed.rs
+++ b/crates/service/src/index/segments/sealed.rs
@@ -58,6 +58,10 @@ impl<S: G> SealedSegment<S> {
     pub fn len(&self) -> u32 {
         self.indexing.len()
     }
+    pub fn size(&self) -> u64 {
+        (self.indexing.len() as u64)
+            * (std::mem::size_of::<S::Scalar>() + std::mem::size_of::<Payload>()) as u64
+    }
     pub fn vector(&self, i: u32) -> &[S::Scalar] {
         self.indexing.vector(i)
     }

--- a/crates/service/src/utils/dir_ops.rs
+++ b/crates/service/src/utils/dir_ops.rs
@@ -14,7 +14,11 @@ pub fn dir_size(dir: &Path) -> io::Result<usize> {
             let entry = entry?;
             let path = entry.path();
             let name = path.file_name().unwrap().to_string_lossy();
-            if path.is_dir() && !name.starts_with('.') {
+            if name.starts_with('.') {
+                // ignore hidden files
+                continue;
+            }
+            if path.is_dir() {
                 size += dir_size(&path)?;
             } else {
                 size += entry.metadata()?.len() as usize;

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -119,7 +119,7 @@ We also provide a view `pg_vector_index_info` to monitor the progress of indexin
 | idx_sealed   | int8[] | The number of tuples in each sealed segment.  |
 | idx_growing  | int8[] | The number of tuples in each growing segment. |
 | idx_write    | int8   | The number of tuples in write buffer.         |
-| idx_size     | text   | The byte size for each segment in the index.  |
+| idx_size     | int8   | The byte size for all the segments.           |
 | idx_config   | text   | The configuration of the index.               |
 
 ## Examples

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -119,6 +119,7 @@ We also provide a view `pg_vector_index_info` to monitor the progress of indexin
 | idx_sealed   | int8[] | The number of tuples in each sealed segment.  |
 | idx_growing  | int8[] | The number of tuples in each growing segment. |
 | idx_write    | int8   | The number of tuples in write buffer.         |
+| idx_size     | text   | The byte size for each segment in the index.  |
 | idx_config   | text   | The configuration of the index.               |
 
 ## Examples

--- a/src/index/views.rs
+++ b/src/index/views.rs
@@ -9,6 +9,7 @@ CREATE TYPE VectorIndexStat AS (
     idx_sealed BIGINT[],
     idx_growing BIGINT[],
     idx_write BIGINT,
+    idx_size BIGINT,
     idx_options TEXT
 );",
     name = "create_composites",
@@ -40,6 +41,7 @@ fn vector_stat(oid: pgrx::pg_sys::Oid) -> pgrx::composite_type!("VectorIndexStat
     })
     .unwrap();
     res.set_by_name("idx_write", stat.write as i64).unwrap();
+    res.set_by_name("idx_size", stat.size as i64).unwrap();
     res.set_by_name("idx_options", serde_json::to_string(&stat.options))
         .unwrap();
     res

--- a/src/index/views.rs
+++ b/src/index/views.rs
@@ -9,7 +9,7 @@ CREATE TYPE VectorIndexStat AS (
     idx_sealed BIGINT[],
     idx_growing BIGINT[],
     idx_write BIGINT,
-    idx_size BIGINT,
+    idx_size TEXT,
     idx_options TEXT
 );",
     name = "create_composites",
@@ -41,7 +41,8 @@ fn vector_stat(oid: pgrx::pg_sys::Oid) -> pgrx::composite_type!("VectorIndexStat
     })
     .unwrap();
     res.set_by_name("idx_write", stat.write as i64).unwrap();
-    res.set_by_name("idx_size", stat.size as i64).unwrap();
+    res.set_by_name("idx_size", serde_json::to_string(&stat.size))
+        .unwrap();
     res.set_by_name("idx_options", serde_json::to_string(&stat.options))
         .unwrap();
     res

--- a/src/index/views.rs
+++ b/src/index/views.rs
@@ -9,7 +9,7 @@ CREATE TYPE VectorIndexStat AS (
     idx_sealed BIGINT[],
     idx_growing BIGINT[],
     idx_write BIGINT,
-    idx_size TEXT,
+    idx_size BIGINT,
     idx_options TEXT
 );",
     name = "create_composites",
@@ -41,8 +41,11 @@ fn vector_stat(oid: pgrx::pg_sys::Oid) -> pgrx::composite_type!("VectorIndexStat
     })
     .unwrap();
     res.set_by_name("idx_write", stat.write as i64).unwrap();
-    res.set_by_name("idx_size", serde_json::to_string(&stat.size))
-        .unwrap();
+    res.set_by_name(
+        "idx_size",
+        stat.sizes.iter().map(|x| x.size as i64).sum::<i64>(),
+    )
+    .unwrap();
     res.set_by_name("idx_options", serde_json::to_string(&stat.options))
         .unwrap();
     res


### PR DESCRIPTION
- fix #185 

```log
vectors=# select tablerelid, idx_size from pg_vector_index_info ;
 tablerelid | idx_size                                         
      16873 | 4
(1 row)
```