### PR TITLE
feat: add optimizing_threads to gucs

### DIFF
--- a/crates/service/src/index/setting.rs
+++ b/crates/service/src/index/setting.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use validator::Validate;
+
+// A flattened NotifiedSetting, Serializable for RPC
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Validate, PartialEq, Eq)]
+pub struct RuntimeOptions {
+    pub optimizing_threads: usize,
+}
+
+// These settings are watched and notified at runtime by index
+pub struct NotifiedSetting {
+    pub optimizing_threads_limit: AtomicUsize,
+}
+
+impl NotifiedSetting {
+    pub fn update(&self, opts: RuntimeOptions) {
+        self.optimizing_threads_limit
+            .store(opts.optimizing_threads, Ordering::Relaxed);
+    }
+
+    pub fn load(&self) -> RuntimeOptions {
+        RuntimeOptions {
+            optimizing_threads: self.optimizing_threads_limit.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for NotifiedSetting {
+    fn default() -> Self {
+        let val = match std::thread::available_parallelism() {
+            Ok(threads) => (threads.get() as f64).sqrt() as _,
+            Err(_) => 1,
+        };
+        NotifiedSetting {
+            optimizing_threads_limit: AtomicUsize::new(val),
+        }
+    }
+}

--- a/crates/service/src/instance/mod.rs
+++ b/crates/service/src/instance/mod.rs
@@ -1,5 +1,6 @@
 pub mod metadata;
 
+use crate::index::setting::RuntimeOptions;
 use crate::index::Index;
 use crate::index::IndexOptions;
 use crate::index::IndexStat;
@@ -132,6 +133,35 @@ impl Instance {
             Instance::F16Dot(x) => Ok(x.stat()),
             Instance::F16L2(x) => Ok(x.stat()),
             Instance::Upgrade => Ok(IndexStat::Upgrade),
+        }
+    }
+    pub fn setting(&self, opts: RuntimeOptions) -> Result<(), FriendlyError> {
+        match self {
+            Instance::F32Cos(x) => {
+                x.setting(opts);
+                Ok(())
+            }
+            Instance::F32Dot(x) => {
+                x.setting(opts);
+                Ok(())
+            }
+            Instance::F32L2(x) => {
+                x.setting(opts);
+                Ok(())
+            }
+            Instance::F16Cos(x) => {
+                x.setting(opts);
+                Ok(())
+            }
+            Instance::F16Dot(x) => {
+                x.setting(opts);
+                Ok(())
+            }
+            Instance::F16L2(x) => {
+                x.setting(opts);
+                Ok(())
+            }
+            Instance::Upgrade => Err(FriendlyError::Upgrade2),
         }
     }
 }

--- a/src/bgworker/upgrade.rs
+++ b/src/bgworker/upgrade.rs
@@ -63,5 +63,6 @@ fn session(handler: RpcHandler) -> Result<(), IpcError> {
         RpcHandle::Destroy { x, .. } => x.reset(FriendlyError::Upgrade)?,
         RpcHandle::Stat { x, .. } => x.reset(FriendlyError::Upgrade)?,
         RpcHandle::Vbase { x, .. } => x.reset(FriendlyError::Upgrade)?,
+        RpcHandle::Setting { x, .. } => x.reset(FriendlyError::Upgrade)?,
     }
 }

--- a/src/gucs.rs
+++ b/src/gucs.rs
@@ -31,6 +31,8 @@ pub static VBASE_RANGE: GucSetting<i32> = GucSetting::<i32>::new(100);
 
 pub static TRANSPORT: GucSetting<Transport> = GucSetting::<Transport>::new(Transport::default());
 
+pub static OPTIMIZING_THREADS_LIMIT: GucSetting<i32> = GucSetting::<i32>::new(0);
+
 pub unsafe fn init() {
     GucRegistry::define_string_guc(
         "vectors.openai_api_key",
@@ -101,5 +103,15 @@ pub unsafe fn init() {
         &TRANSPORT,
         GucContext::Userset,
         GucFlags::default(),
-    )
+    );
+    GucRegistry::define_int_guc(
+        "vectors.optimizing_threads_limit",
+        "Maximum threads for index optimizing.",
+        "Maximum threads for optimizer of each index, 0 for no limit.",
+        &OPTIMIZING_THREADS_LIMIT,
+        0,
+        65535,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }

--- a/src/ipc/client/mod.rs
+++ b/src/ipc/client/mod.rs
@@ -2,6 +2,7 @@ use super::packet::*;
 use super::transport::ClientSocket;
 use crate::gucs::{Transport, TRANSPORT};
 use crate::utils::cells::PgRefCell;
+use service::index::setting::RuntimeOptions;
 use service::index::IndexOptions;
 use service::index::IndexStat;
 use service::index::SearchOptions;
@@ -40,7 +41,6 @@ impl<T: ClientLike> DerefMut for ClientGuard<T> {
         &mut self.0
     }
 }
-
 pub struct Rpc {
     socket: ClientSocket,
 }
@@ -121,6 +121,11 @@ impl ClientGuard<Rpc> {
         self.socket.send(packet).friendly();
         let stat::StatPacket::Leave { result } = self.socket.recv().friendly();
         result
+    }
+    pub fn setting(&mut self, opts: RuntimeOptions) {
+        let packet = RpcPacket::Setting { opts };
+        self.socket.send(packet).friendly();
+        let setting::SettingPacket::Leave {} = self.socket.recv().friendly();
     }
     pub fn vbase(
         mut self,

--- a/src/ipc/packet/mod.rs
+++ b/src/ipc/packet/mod.rs
@@ -4,10 +4,12 @@ pub mod destroy;
 pub mod flush;
 pub mod insert;
 pub mod search;
+pub mod setting;
 pub mod stat;
 pub mod vbase;
 
 use serde::{Deserialize, Serialize};
+use service::index::setting::RuntimeOptions;
 use service::index::IndexOptions;
 use service::index::SearchOptions;
 use service::prelude::*;
@@ -36,6 +38,9 @@ pub enum RpcPacket {
         vector: DynamicVector,
         prefilter: bool,
         opts: SearchOptions,
+    },
+    Setting {
+        opts: RuntimeOptions,
     },
     Stat {
         handle: Handle,

--- a/src/ipc/packet/setting.rs
+++ b/src/ipc/packet/setting.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum SettingPacket {
+    Leave {},
+}


### PR DESCRIPTION
Fix #195 
# Design

~~To use a `assign_hook` function, we export `unsafe DefineCustomIntVariable` from `pgrx`, instead of calling `GucRegistry::define_int_guc`.~~

[updated 2024/01/04]

I struggled with `assign_hook` and finally failed. To send RPC from hooked function would forbidden pg from starting. It seems import crate `let mut rpc = crate::ipc::client::borrow_mut();` caused that fault.

Now I use a simple Timer to sync `OPTIMIZING_THREADS` and call RPC.

We introduce 3 settings for this Callback feature:
- `RuntimeOptions`: A flattened Setting, Serializable for RPC
- `NotifiedSetting`: Arc\<Atomic\>, maintained by `Index`, could be restored from `IndexOptions`
- `SharedSetting`: Weak\<Atomic\>, maintained by `OptimizerIndexing`, downgraded from `NotifiedSetting`


The `assign_hook` would call RPC `setting` and set `NotifiedSetting` maintainered by `Index`, while optimizer would fetch `optimizing_threads` from a Weak reference `SharedSetting` from `NotifiedSetting.downgrade()`.

By this method, Arc could be fixed always in single process.

[updated 2024/01/05]
Now we have:
- GUCS `vectors.optimizing_threads_limit` for global limit for all indexes(Default 0 for no limit)
- Option `optimizing_threads` for each index

The threads of optimizing would be mininal of them, and if `vectors.optimizing_threads_limit==0`, there is no global limit.

