### PR TITLE
chore: stable schema generation

### DIFF
--- a/src/datatype/casts_f32.rs
+++ b/src/datatype/casts_f32.rs
@@ -3,7 +3,7 @@ use crate::datatype::vecf32::{Vecf32, Vecf32Input, Vecf32Output};
 use service::prelude::*;
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn vecf32_cast_array_to_vector(
+fn _vectors_cast_array_to_vecf32(
     array: pgrx::Array<f32>,
     typmod: i32,
     _explicit: bool,
@@ -21,6 +21,10 @@ fn vecf32_cast_array_to_vector(
 }
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn vecf32_cast_vector_to_array(vector: Vecf32Input<'_>, _typmod: i32, _explicit: bool) -> Vec<f32> {
+fn _vectors_cast_vecf32_to_array(
+    vector: Vecf32Input<'_>,
+    _typmod: i32,
+    _explicit: bool,
+) -> Vec<f32> {
     vector.data().iter().map(|x| x.to_f32()).collect()
 }

--- a/src/datatype/operators_f16.rs
+++ b/src/datatype/operators_f16.rs
@@ -3,10 +3,8 @@ use crate::prelude::*;
 use service::prelude::*;
 use std::ops::Deref;
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(+)]
-#[pgrx::commutator(+)]
-fn vecf16_operator_add(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> Vecf16Output {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_add(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> Vecf16Output {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -22,9 +20,8 @@ fn vecf16_operator_add(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> Vecf16Outp
     Vecf16::new_in_postgres(&v)
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(-)]
-fn vecf16_operator_minus(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> Vecf16Output {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_minus(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> Vecf16Output {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -40,13 +37,8 @@ fn vecf16_operator_minus(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> Vecf16Ou
     Vecf16::new_in_postgres(&v)
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(<)]
-#[pgrx::negator(>=)]
-#[pgrx::commutator(>)]
-#[pgrx::restrict(scalarltsel)]
-#[pgrx::join(scalarltjoinsel)]
-fn vecf16_operator_lt(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_lt(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -57,13 +49,8 @@ fn vecf16_operator_lt(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     lhs.deref() < rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(<=)]
-#[pgrx::negator(>)]
-#[pgrx::commutator(>=)]
-#[pgrx::restrict(scalarltsel)]
-#[pgrx::join(scalarltjoinsel)]
-fn vecf16_operator_lte(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_lte(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -74,13 +61,8 @@ fn vecf16_operator_lte(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     lhs.deref() <= rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(>)]
-#[pgrx::negator(<=)]
-#[pgrx::commutator(<)]
-#[pgrx::restrict(scalargtsel)]
-#[pgrx::join(scalargtjoinsel)]
-fn vecf16_operator_gt(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_gt(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -91,13 +73,8 @@ fn vecf16_operator_gt(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     lhs.deref() > rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(>=)]
-#[pgrx::negator(<)]
-#[pgrx::commutator(<=)]
-#[pgrx::restrict(scalargtsel)]
-#[pgrx::join(scalargtjoinsel)]
-fn vecf16_operator_gte(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_gte(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -108,13 +85,8 @@ fn vecf16_operator_gte(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     lhs.deref() >= rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(=)]
-#[pgrx::negator(<>)]
-#[pgrx::commutator(=)]
-#[pgrx::restrict(eqsel)]
-#[pgrx::join(eqjoinsel)]
-fn vecf16_operator_eq(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_eq(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -125,13 +97,8 @@ fn vecf16_operator_eq(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     lhs.deref() == rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(<>)]
-#[pgrx::negator(=)]
-#[pgrx::commutator(<>)]
-#[pgrx::restrict(eqsel)]
-#[pgrx::join(eqjoinsel)]
-fn vecf16_operator_neq(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_neq(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -142,10 +109,8 @@ fn vecf16_operator_neq(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> bool {
     lhs.deref() != rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(<=>)]
-#[pgrx::commutator(<=>)]
-fn vecf16_operator_cosine(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_cosine(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -156,10 +121,8 @@ fn vecf16_operator_cosine(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
     F16Cos::distance(&lhs, &rhs).to_f32()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(<#>)]
-#[pgrx::commutator(<#>)]
-fn vecf16_operator_dot(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_dot(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -170,10 +133,8 @@ fn vecf16_operator_dot(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
     F16Dot::distance(&lhs, &rhs).to_f32()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf16"])]
-#[pgrx::opname(<->)]
-#[pgrx::commutator(<->)]
-fn vecf16_operator_l2(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf16_operator_l2(lhs: Vecf16Input<'_>, rhs: Vecf16Input<'_>) -> f32 {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,

--- a/src/datatype/operators_f32.rs
+++ b/src/datatype/operators_f32.rs
@@ -3,10 +3,8 @@ use crate::prelude::*;
 use service::prelude::*;
 use std::ops::Deref;
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(+)]
-#[pgrx::commutator(+)]
-fn vecf32_operator_add(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> Vecf32Output {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_add(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> Vecf32Output {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -22,9 +20,8 @@ fn vecf32_operator_add(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> Vecf32Outp
     Vecf32::new_in_postgres(&v)
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(-)]
-fn vecf32_operator_minus(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> Vecf32Output {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_minus(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> Vecf32Output {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -40,13 +37,8 @@ fn vecf32_operator_minus(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> Vecf32Ou
     Vecf32::new_in_postgres(&v)
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(<)]
-#[pgrx::negator(>=)]
-#[pgrx::commutator(>)]
-#[pgrx::restrict(scalarltsel)]
-#[pgrx::join(scalarltjoinsel)]
-fn vecf32_operator_lt(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_lt(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -57,13 +49,8 @@ fn vecf32_operator_lt(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     lhs.deref() < rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(<=)]
-#[pgrx::negator(>)]
-#[pgrx::commutator(>=)]
-#[pgrx::restrict(scalarltsel)]
-#[pgrx::join(scalarltjoinsel)]
-fn vecf32_operator_lte(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_lte(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -74,13 +61,8 @@ fn vecf32_operator_lte(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     lhs.deref() <= rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(>)]
-#[pgrx::negator(<=)]
-#[pgrx::commutator(<)]
-#[pgrx::restrict(scalargtsel)]
-#[pgrx::join(scalargtjoinsel)]
-fn vecf32_operator_gt(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_gt(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -91,13 +73,8 @@ fn vecf32_operator_gt(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     lhs.deref() > rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(>=)]
-#[pgrx::negator(<)]
-#[pgrx::commutator(<=)]
-#[pgrx::restrict(scalargtsel)]
-#[pgrx::join(scalargtjoinsel)]
-fn vecf32_operator_gte(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_gte(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -108,13 +85,8 @@ fn vecf32_operator_gte(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     lhs.deref() >= rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(=)]
-#[pgrx::negator(<>)]
-#[pgrx::commutator(=)]
-#[pgrx::restrict(eqsel)]
-#[pgrx::join(eqjoinsel)]
-fn vecf32_operator_eq(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_eq(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -125,13 +97,8 @@ fn vecf32_operator_eq(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     lhs.deref() == rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(<>)]
-#[pgrx::negator(=)]
-#[pgrx::commutator(<>)]
-#[pgrx::restrict(eqsel)]
-#[pgrx::join(eqjoinsel)]
-fn vecf32_operator_neq(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_neq(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -142,10 +109,8 @@ fn vecf32_operator_neq(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> bool {
     lhs.deref() != rhs.deref()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(<=>)]
-#[pgrx::commutator(<=>)]
-fn vecf32_operator_cosine(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_cosine(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -156,10 +121,8 @@ fn vecf32_operator_cosine(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
     F32Cos::distance(&lhs, &rhs).to_f32()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(<#>)]
-#[pgrx::commutator(<#>)]
-fn vecf32_operator_dot(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_dot(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,
@@ -170,10 +133,8 @@ fn vecf32_operator_dot(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
     F32Dot::distance(&lhs, &rhs).to_f32()
 }
 
-#[pgrx::pg_operator(immutable, parallel_safe, requires = ["vecf32"])]
-#[pgrx::opname(<->)]
-#[pgrx::commutator(<->)]
-fn vecf32_operator_l2(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
+#[pgrx::pg_extern(immutable, parallel_safe)]
+fn _vectors_vecf32_operator_l2(lhs: Vecf32Input<'_>, rhs: Vecf32Input<'_>) -> f32 {
     if lhs.len() != rhs.len() {
         SessionError::Unmatched {
             left_dimensions: lhs.len() as _,

--- a/src/datatype/typmod.rs
+++ b/src/datatype/typmod.rs
@@ -53,7 +53,7 @@ impl Typmod {
 }
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn typmod_in(list: Array<&CStr>) -> i32 {
+fn _vectors_typmod_in(list: Array<&CStr>) -> i32 {
     if list.is_empty() {
         -1
     } else if list.len() == 1 {
@@ -68,7 +68,7 @@ fn typmod_in(list: Array<&CStr>) -> i32 {
 }
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn typmod_out(typmod: i32) -> CString {
+fn _vectors_typmod_out(typmod: i32) -> CString {
     let typmod = Typmod::parse_from_i32(typmod).unwrap();
     match typmod.into_option_string() {
         Some(s) => CString::new(format!("({})", s)).unwrap(),

--- a/src/datatype/vecf16.rs
+++ b/src/datatype/vecf16.rs
@@ -20,23 +20,6 @@ use std::ops::Index;
 use std::ops::IndexMut;
 use std::ptr::NonNull;
 
-pgrx::extension_sql!(
-    r#"
-CREATE TYPE vecf16 (
-    INPUT     = vecf16_in,
-    OUTPUT    = vecf16_out,
-    TYPMOD_IN = typmod_in,
-    TYPMOD_OUT = typmod_out,
-    STORAGE   = EXTENDED,
-    INTERNALLENGTH = VARIABLE,
-    ALIGNMENT = double
-);
-"#,
-    name = "vecf16",
-    creates = [Type(Vecf16)],
-    requires = [vecf16_in, vecf16_out, typmod_in, typmod_out],
-);
-
 #[repr(C, align(8))]
 pub struct Vecf16 {
     varlena: u32,
@@ -266,7 +249,7 @@ unsafe impl SqlTranslatable for Vecf16Output {
 }
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn vecf16_in(input: &CStr, _oid: Oid, typmod: i32) -> Vecf16Output {
+fn _vectors_vecf16_in(input: &CStr, _oid: Oid, typmod: i32) -> Vecf16Output {
     fn solve<T>(option: Option<T>, hint: &str) -> T {
         if let Some(x) = option {
             x
@@ -330,7 +313,7 @@ fn vecf16_in(input: &CStr, _oid: Oid, typmod: i32) -> Vecf16Output {
 }
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn vecf16_out(vector: Vecf16Input<'_>) -> CString {
+fn _vectors_vecf16_out(vector: Vecf16Input<'_>) -> CString {
     let mut buffer = String::new();
     buffer.push('[');
     if let Some(&x) = vector.data().first() {

--- a/src/datatype/vecf32.rs
+++ b/src/datatype/vecf32.rs
@@ -20,23 +20,6 @@ use std::ops::Index;
 use std::ops::IndexMut;
 use std::ptr::NonNull;
 
-pgrx::extension_sql!(
-    r#"
-CREATE TYPE vector (
-    INPUT     = vecf32_in,
-    OUTPUT    = vecf32_out,
-    TYPMOD_IN = typmod_in,
-    TYPMOD_OUT = typmod_out,
-    STORAGE   = EXTENDED,
-    INTERNALLENGTH = VARIABLE,
-    ALIGNMENT = double
-);
-"#,
-    name = "vecf32",
-    creates = [Type(Vecf32)],
-    requires = [vecf32_in, vecf32_out, typmod_in, typmod_out],
-);
-
 #[repr(C, align(8))]
 pub struct Vecf32 {
     varlena: u32,
@@ -266,7 +249,7 @@ unsafe impl SqlTranslatable for Vecf32Output {
 }
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn vecf32_in(input: &CStr, _oid: Oid, typmod: i32) -> Vecf32Output {
+fn _vectors_vecf32_in(input: &CStr, _oid: Oid, typmod: i32) -> Vecf32Output {
     fn solve<T>(option: Option<T>, hint: &str) -> T {
         if let Some(x) = option {
             x
@@ -330,7 +313,7 @@ fn vecf32_in(input: &CStr, _oid: Oid, typmod: i32) -> Vecf32Output {
 }
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
-fn vecf32_out(vector: Vecf32Input<'_>) -> CString {
+fn _vectors_vecf32_out(vector: Vecf32Input<'_>) -> CString {
     let mut buffer = String::new();
     buffer.push('[');
     if let Some(&x) = vector.data().first() {

--- a/src/embedding/udf.rs
+++ b/src/embedding/udf.rs
@@ -5,8 +5,8 @@ use crate::gucs::OPENAI_API_KEY_GUC;
 use pgrx::prelude::*;
 use service::prelude::F32;
 
-#[pg_extern]
-fn ai_embedding_vector(input: String) -> Vecf32Output {
+#[pgrx::pg_extern(volatile, strict)]
+fn _vectors_ai_embedding_vector(input: String) -> Vecf32Output {
     let api_key = match OPENAI_API_KEY_GUC.get() {
         Some(key) => key
             .to_str()

--- a/src/index/views.rs
+++ b/src/index/views.rs
@@ -1,26 +1,11 @@
 use crate::prelude::*;
 use service::prelude::*;
 
-pgrx::extension_sql!(
-    "\
-CREATE TYPE VectorIndexStat AS (
-    idx_status TEXT,
-    idx_indexing BOOL,
-    idx_tuples BIGINT,
-    idx_sealed BIGINT[],
-    idx_growing BIGINT[],
-    idx_write BIGINT,
-    idx_size BIGINT,
-    idx_options TEXT
-);",
-    name = "create_composites",
-);
-
 #[pgrx::pg_extern(volatile, strict)]
-fn vector_stat(oid: pgrx::pg_sys::Oid) -> pgrx::composite_type!("VectorIndexStat") {
+fn _vectors_index_stat(oid: pgrx::pg_sys::Oid) -> pgrx::composite_type!("vector_index_stat") {
     use service::index::IndexStat;
     let id = Handle::from_sys(oid);
-    let mut res = pgrx::prelude::PgHeapTuple::new_composite_type("VectorIndexStat").unwrap();
+    let mut res = pgrx::prelude::PgHeapTuple::new_composite_type("vector_index_stat").unwrap();
     let mut rpc = crate::ipc::client::borrow_mut();
     let stat = rpc.stat(id);
     match stat {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,22 +35,14 @@ unsafe extern "C" fn _PG_init() {
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "freebsd")))]
 compile_error!("Target is not supported.");
 
-#[cfg(not(target_endian = "little"))]
+#[cfg(not(all(target_endian = "little", target_pointer_width = "64")))]
 compile_error!("Target is not supported.");
 
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("Target is not supported.");
-
-/// This module is required by `cargo pgrx test` invocations.
-/// It must be visible at the root of your extension crate.
 #[cfg(test)]
 pub mod pg_test {
-    pub fn setup(_options: Vec<&str>) {
-        // perform one-off initialization when the pg_test framework starts
-    }
+    pub fn setup(_options: Vec<&str>) {}
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
-        // return any postgresql.conf settings that are required for your tests
-        vec![]
+        vec!["shared_preload_libraries = 'vectors'"]
     }
 }

--- a/src/sql/bootstrap.sql
+++ b/src/sql/bootstrap.sql
@@ -1,2 +1,9 @@
+-- bootstrap begin
+
+-- List of shell types
+
 CREATE TYPE vector;
 CREATE TYPE vecf16;
+CREATE TYPE vector_index_stat;
+
+-- bootstrap end

--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -1,11 +1,244 @@
+-- finalize begin
+
+-- List of data types
+
+CREATE TYPE vector (
+    INPUT = _vectors_vecf32_in,
+    OUTPUT = _vectors_vecf32_out,
+    TYPMOD_IN = _vectors_typmod_in,
+    TYPMOD_OUT = _vectors_typmod_out,
+    STORAGE = EXTENDED,
+    INTERNALLENGTH = VARIABLE,
+    ALIGNMENT = double
+);
+
+CREATE TYPE vecf16 (
+    INPUT = _vectors_vecf16_in,
+    OUTPUT = _vectors_vecf16_out,
+    TYPMOD_IN = _vectors_typmod_in,
+    TYPMOD_OUT = _vectors_typmod_out,
+    STORAGE = EXTENDED,
+    INTERNALLENGTH = VARIABLE,
+    ALIGNMENT = double
+);
+
+CREATE TYPE vector_index_stat AS (
+    idx_status TEXT,
+    idx_indexing BOOL,
+    idx_tuples BIGINT,
+    idx_sealed BIGINT[],
+    idx_growing BIGINT[],
+    idx_write BIGINT,
+    idx_size BIGINT,
+    idx_options TEXT
+);
+
+-- List of operators
+
+CREATE OPERATOR + (
+	PROCEDURE = _vectors_vecf32_operator_add,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = +
+);
+
+CREATE OPERATOR + (
+	PROCEDURE = _vectors_vecf16_operator_add,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = +
+);
+
+CREATE OPERATOR - (
+	PROCEDURE = _vectors_vecf32_operator_minus,
+	LEFTARG = vector,
+	RIGHTARG = vector
+);
+
+CREATE OPERATOR - (
+	PROCEDURE = _vectors_vecf16_operator_minus,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16
+);
+
+CREATE OPERATOR = (
+	PROCEDURE = _vectors_vecf32_operator_eq,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = =,
+	NEGATOR = <>,
+	RESTRICT = eqsel,
+	JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+	PROCEDURE = _vectors_vecf16_operator_eq,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = =,
+	NEGATOR = <>,
+	RESTRICT = eqsel,
+	JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+	PROCEDURE = _vectors_vecf32_operator_neq,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = <>,
+	NEGATOR = =,
+	RESTRICT = eqsel,
+	JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+	PROCEDURE = _vectors_vecf16_operator_neq,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = <>,
+	NEGATOR = =,
+	RESTRICT = eqsel,
+	JOIN = eqjoinsel
+);
+
+CREATE OPERATOR < (
+	PROCEDURE = _vectors_vecf32_operator_lt,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = >,
+	NEGATOR = >=,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+	PROCEDURE = _vectors_vecf16_operator_lt,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = >,
+	NEGATOR = >=,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR > (
+	PROCEDURE = _vectors_vecf32_operator_gt,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = <,
+	NEGATOR = <=,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+	PROCEDURE = _vectors_vecf16_operator_gt,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = <,
+	NEGATOR = <=,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR <= (
+	PROCEDURE = _vectors_vecf32_operator_lte,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = >=,
+	NEGATOR = >,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+	PROCEDURE = _vectors_vecf16_operator_lte,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = >=,
+	NEGATOR = >,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR >= (
+	PROCEDURE = _vectors_vecf32_operator_gte,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = <=,
+	NEGATOR = <,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+	PROCEDURE = _vectors_vecf16_operator_gte,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = <=,
+	NEGATOR = <,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR <-> (
+	PROCEDURE = _vectors_vecf32_operator_l2,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = <->
+);
+
+CREATE OPERATOR <-> (
+	PROCEDURE = _vectors_vecf16_operator_l2,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = <->
+);
+
+CREATE OPERATOR <#> (
+	PROCEDURE = _vectors_vecf32_operator_dot,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = <#>
+);
+
+CREATE OPERATOR <#> (
+	PROCEDURE = _vectors_vecf16_operator_dot,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = <#>
+);
+
+CREATE OPERATOR <=> (
+	PROCEDURE = _vectors_vecf32_operator_cosine,
+	LEFTARG = vector,
+	RIGHTARG = vector,
+	COMMUTATOR = <=>
+);
+
+CREATE OPERATOR <=> (
+	PROCEDURE = _vectors_vecf16_operator_cosine,
+	LEFTARG = vecf16,
+	RIGHTARG = vecf16,
+	COMMUTATOR = <=>
+);
+
+-- List of functions
+
+-- List of casts
+
 CREATE CAST (real[] AS vector)
-    WITH FUNCTION vecf32_cast_array_to_vector(real[], integer, boolean) AS IMPLICIT;
+    WITH FUNCTION _vectors_cast_array_to_vecf32(real[], integer, boolean) AS IMPLICIT;
 
 CREATE CAST (vector AS real[])
-    WITH FUNCTION vecf32_cast_vector_to_array(vector, integer, boolean) AS IMPLICIT;
+    WITH FUNCTION _vectors_cast_vecf32_to_array(vector, integer, boolean) AS IMPLICIT;
 
-CREATE ACCESS METHOD vectors TYPE INDEX HANDLER vectors_amhandler;
+-- List of access methods
+
+CREATE ACCESS METHOD vectors TYPE INDEX HANDLER _vectors_amhandler;
 COMMENT ON ACCESS METHOD vectors IS 'pgvecto.rs index access method';
+
+-- List of operator classes
 
 CREATE OPERATOR CLASS vector_l2_ops
     FOR TYPE vector USING vectors AS
@@ -31,15 +264,19 @@ CREATE OPERATOR CLASS vecf16_cos_ops
     FOR TYPE vecf16 USING vectors AS
     OPERATOR 1 <=> (vecf16, vecf16) FOR ORDER BY float_ops;
 
-CREATE VIEW pg_vector_index_info AS
+-- List of views
+
+CREATE VIEW pg_vector_index_stat AS
     SELECT
         C.oid AS tablerelid,
         I.oid AS indexrelid,
         C.relname AS tablename,
         I.relname AS indexname,
-        (vector_stat(I.relfilenode)).*
+        (_vectors_index_stat(I.relfilenode)).*
     FROM pg_class C JOIN
          pg_index X ON C.oid = X.indrelid JOIN
          pg_class I ON I.oid = X.indexrelid JOIN
          pg_am A ON A.oid = I.relam
     WHERE A.amname = 'vectors';
+
+-- finalize end


### PR DESCRIPTION
* PR in pgvecto.rs: https://github.com/tensorchord/pgvecto.rs/pull/254
* PR in pgvecto.rs-docs: https://github.com/tensorchord/pgvecto.rs-docs/pull/8

Currently we rely on pgrx to generate SQL schema. However it's hard to track generated schema and write a update script.

We will:

* do not use `pg_*` macros, expect for `pg_extern` attached to `_vectors_*`
* write schema in `finalize.sql`
* document schema in pgvecto.rs-docs