### PR TITLE
feat: add compat with pgvector

### DIFF
--- a/src/gucs/planning.rs
+++ b/src/gucs/planning.rs
@@ -11,6 +11,8 @@ pub static ENABLE_INDEX: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 pub static SEARCH_MODE: GucSetting<Mode> = GucSetting::<Mode>::new(Mode::basic);
 
+pub static ENABLE_PGVECTOR_COMPATIBILITY: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 pub unsafe fn init() {
     GucRegistry::define_bool_guc(
         "vectors.enable_index",
@@ -28,4 +30,12 @@ pub unsafe fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
+    GucRegistry::define_bool_guc(
+        "vectors.pgvector_compatibility",
+        "Enables or disables pgvector compatibility mode.",
+        "https://docs.pgvecto.rs/usage/compatibility.html",
+        &ENABLE_PGVECTOR_COMPATIBILITY,
+        GucContext::Userset,
+        GucFlags::default(),
+    )
 }

--- a/src/index/compat.rs
+++ b/src/index/compat.rs
@@ -1,0 +1,188 @@
+use crate::gucs::planning::ENABLE_PGVECTOR_COMPATIBILITY;
+use libc::c_void;
+use pgrx::pg_sys::pfree;
+use pgrx::pg_sys::AsPgCStr;
+use std::collections::HashMap;
+use std::ffi::CStr;
+
+unsafe fn swap_destroy<T>(target: &mut *mut T, value: *mut T) {
+    let ptr = *target;
+    *target = value;
+    if !ptr.is_null() {
+        unsafe {
+            pfree(ptr.cast());
+        }
+    }
+}
+
+pub unsafe fn pgvector_stmt_rewrite(pstmt: *mut pgrx::pg_sys::PlannedStmt) {
+    let enabled = ENABLE_PGVECTOR_COMPATIBILITY.get();
+    if !enabled {
+        return;
+    }
+    unsafe {
+        let utility_statement = (*pstmt).utilityStmt;
+        let is_index = pgrx::is_a(utility_statement, pgrx::pg_sys::NodeTag::T_IndexStmt);
+
+        if is_index {
+            let istmt: *mut pgrx::pg_sys::IndexStmt = utility_statement.cast();
+            if istmt.is_null() {
+                return;
+            }
+            let method = CStr::from_ptr((*istmt).accessMethod).to_str();
+            if method == Ok("hnsw") || method == Ok("ivfflat") {
+                rewrite_type_options(istmt, method.unwrap());
+                rewrite_opclass(istmt);
+                swap_destroy(&mut (*istmt).accessMethod, "vectors".as_pg_cstr());
+            }
+        }
+    }
+}
+
+unsafe fn rewrite_type_options(istmt: *mut pgrx::pg_sys::IndexStmt, method: &str) {
+    unsafe {
+        let original = vec_from_list((*istmt).options);
+        let opts = options_from_vec(original);
+        match method {
+            "hnsw" => {
+                let m = opts
+                    .get("m")
+                    .unwrap_or(&String::from("16"))
+                    .parse::<u32>()
+                    .unwrap();
+                let ef_construction = opts
+                    .get("ef_construction")
+                    .unwrap_or(&String::from("64"))
+                    .parse::<usize>()
+                    .unwrap();
+                let arg = pgrx::pg_sys::makeString(
+                    format!(
+                        "[indexing.hnsw]\nm = {}\nef_construction = {}",
+                        m, ef_construction
+                    )
+                    .as_pg_cstr(),
+                );
+                let elem = pgrx::pg_sys::makeDefElem("options".as_pg_cstr(), arg as _, -1);
+                swap_destroy(&mut (*istmt).options, list_from_vec(vec![elem]));
+            }
+            "ivfflat" => {
+                let nlist = opts
+                    .get("list")
+                    .unwrap_or(&String::from("100"))
+                    .parse::<u32>()
+                    .unwrap();
+                let arg = pgrx::pg_sys::makeString(
+                    format!("[indexing.ivf]\nnlist = {}", nlist).as_pg_cstr(),
+                );
+                let elem = pgrx::pg_sys::makeDefElem("options".as_pg_cstr(), arg as _, -1);
+                swap_destroy(&mut (*istmt).options, list_from_vec(vec![elem]));
+            }
+            _ => {}
+        }
+    }
+}
+
+unsafe fn rewrite_opclass(istmt: *mut pgrx::pg_sys::IndexStmt) {
+    unsafe {
+        let elems = vec_from_list::<pgrx::pg_sys::IndexElem>((*istmt).indexParams);
+        if elems.is_empty() {
+            return;
+        }
+        for e in elems {
+            let opclass_name = vec_from_list::<c_void>((*e).opclass)
+                .into_iter()
+                .next()
+                .unwrap();
+            if opclass_name.is_null() {
+                continue;
+            }
+            #[cfg(any(feature = "pg15", feature = "pg16"))]
+            let opclass_ptr = (*(opclass_name as *mut pgrx::pg_sys::String)).sval;
+            #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14"))]
+            let opclass_ptr = (*(opclass_name as *mut pgrx::pg_sys::Value)).val.str_;
+            let opclass = match CStr::from_ptr(opclass_ptr).to_str() {
+                Ok("vector_l2_ops") => "vector_l2_ops",
+                Ok("vector_ip_ops") => "vector_dot_ops",
+                Ok("vector_cosine_ops") => "vector_cos_ops",
+                Ok(other) => {
+                    pgrx::warning!(
+                        "Operator class '{other}' not recognized, will not be overwritten"
+                    );
+                    return;
+                }
+                Err(e) => {
+                    pgrx::warning!("Operator class parse failed, will not be overwritten: {e}");
+                    return;
+                }
+            };
+            let opclass = pgrx::pg_sys::makeString(opclass.as_pg_cstr());
+            swap_destroy(&mut (*e).opclass, list_from_vec(vec![opclass]));
+        }
+    }
+}
+
+pub unsafe fn options_from_vec(vec: Vec<*mut pgrx::pg_sys::DefElem>) -> HashMap<String, String> {
+    let mut options = HashMap::new();
+    if vec.is_empty() {
+        return options;
+    }
+    for e in vec {
+        unsafe {
+            let defname = CStr::from_ptr((*e).defname).to_str().unwrap().to_owned();
+            let defvalue = CStr::from_ptr(pgrx::pg_sys::defGetString(e))
+                .to_str()
+                .unwrap()
+                .to_owned();
+            options.insert(defname, defvalue);
+        }
+    }
+    options
+}
+
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+pub unsafe fn vec_from_list<T>(l: *mut pgrx::pg_sys::List) -> Vec<*mut T> {
+    let mut vec = Vec::new();
+    if l.is_null() {
+        return vec;
+    }
+    unsafe {
+        let length = (*l).length as usize;
+        for i in 0..length {
+            let cell = (*l).elements.add(i);
+            vec.push((*cell).ptr_value as *mut T)
+        }
+    }
+    vec
+}
+
+#[cfg(feature = "pg12")]
+pub unsafe fn vec_from_list<T>(l: *mut pgrx::pg_sys::List) -> Vec<*mut T> {
+    let mut vec: Vec<*mut T> = Vec::new();
+    if l.is_null() {
+        return vec;
+    }
+    unsafe {
+        let length = (*l).length;
+        let mut elem = (*l).head;
+        for _ in 0..length {
+            let e = (*elem).data.ptr_value as *mut T;
+            vec.push(e);
+            elem = (*elem).next;
+        }
+    }
+    vec
+}
+
+pub unsafe fn list_from_vec<T>(vec: Vec<*mut T>) -> *mut pgrx::pg_sys::List {
+    use std::ptr;
+    if vec.is_empty() {
+        return ptr::null_mut();
+    }
+    let mut newlist: *mut pgrx::prelude::pg_sys::List = ptr::null_mut();
+    for elem in vec {
+        unsafe {
+            newlist = pgrx::pg_sys::list_append_unique(newlist, elem as _);
+        }
+    }
+    newlist
+}

--- a/src/index/hooks.rs
+++ b/src/index/hooks.rs
@@ -1,4 +1,7 @@
+use crate::index::compat::pgvector_stmt_rewrite;
+
 static mut PREV_EXECUTOR_START: pgrx::pg_sys::ExecutorStart_hook_type = None;
+static mut PREV_PROCESS_UTILITY: pgrx::pg_sys::ProcessUtility_hook_type = None;
 
 #[pgrx::pg_guard]
 unsafe extern "C" fn vectors_executor_start(
@@ -14,6 +17,126 @@ unsafe extern "C" fn vectors_executor_start(
     }
     unsafe {
         super::hook_executor::post_executor_start(query_desc);
+    }
+}
+
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16"))]
+#[pgrx::pg_guard]
+unsafe extern "C" fn hook_pgvector_compatibility(
+    pstmt: *mut pgrx::pg_sys::PlannedStmt,
+    query_string: *const ::std::os::raw::c_char,
+    read_only_tree: bool,
+    context: pgrx::pg_sys::ProcessUtilityContext,
+    params: pgrx::pg_sys::ParamListInfo,
+    query_env: *mut pgrx::pg_sys::QueryEnvironment,
+    dest: *mut pgrx::pg_sys::DestReceiver,
+    completion_tag: *mut pgrx::pg_sys::QueryCompletion,
+) {
+    unsafe {
+        pgvector_stmt_rewrite(pstmt);
+    }
+    unsafe {
+        if let Some(prev_process_utility) = PREV_PROCESS_UTILITY {
+            prev_process_utility(
+                pstmt,
+                query_string,
+                read_only_tree,
+                context,
+                params,
+                query_env,
+                dest,
+                completion_tag,
+            );
+        } else {
+            pgrx::pg_sys::standard_ProcessUtility(
+                pstmt,
+                query_string,
+                read_only_tree,
+                context,
+                params,
+                query_env,
+                dest,
+                completion_tag,
+            );
+        }
+    }
+}
+
+#[cfg(feature = "pg13")]
+#[pgrx::pg_guard]
+unsafe extern "C" fn hook_pgvector_compatibility(
+    pstmt: *mut pgrx::pg_sys::PlannedStmt,
+    query_string: *const ::std::os::raw::c_char,
+    context: pgrx::pg_sys::ProcessUtilityContext,
+    params: pgrx::pg_sys::ParamListInfo,
+    query_env: *mut pgrx::pg_sys::QueryEnvironment,
+    dest: *mut pgrx::pg_sys::DestReceiver,
+    completion_tag: *mut pgrx::pg_sys::QueryCompletion,
+) {
+    unsafe {
+        pgvector_stmt_rewrite(pstmt);
+    }
+    unsafe {
+        if let Some(prev_process_utility) = PREV_PROCESS_UTILITY {
+            prev_process_utility(
+                pstmt,
+                query_string,
+                context,
+                params,
+                query_env,
+                dest,
+                completion_tag,
+            );
+        } else {
+            pgrx::pg_sys::standard_ProcessUtility(
+                pstmt,
+                query_string,
+                context,
+                params,
+                query_env,
+                dest,
+                completion_tag,
+            );
+        }
+    }
+}
+
+#[cfg(feature = "pg12")]
+#[pgrx::pg_guard]
+unsafe extern "C" fn hook_pgvector_compatibility(
+    pstmt: *mut pgrx::pg_sys::PlannedStmt,
+    query_string: *const ::std::os::raw::c_char,
+    context: pgrx::pg_sys::ProcessUtilityContext,
+    params: pgrx::pg_sys::ParamListInfo,
+    query_env: *mut pgrx::pg_sys::QueryEnvironment,
+    dest: *mut pgrx::pg_sys::DestReceiver,
+    completion_tag: *mut ::std::os::raw::c_char,
+) {
+    unsafe {
+        pgvector_stmt_rewrite(pstmt);
+    }
+    unsafe {
+        if let Some(prev_process_utility) = PREV_PROCESS_UTILITY {
+            prev_process_utility(
+                pstmt,
+                query_string,
+                context,
+                params,
+                query_env,
+                dest,
+                completion_tag,
+            );
+        } else {
+            pgrx::pg_sys::standard_ProcessUtility(
+                pstmt,
+                query_string,
+                context,
+                params,
+                query_env,
+                dest,
+                completion_tag,
+            );
+        }
     }
 }
 
@@ -36,6 +159,8 @@ pub unsafe fn init() {
     unsafe {
         PREV_EXECUTOR_START = pgrx::pg_sys::ExecutorStart_hook;
         pgrx::pg_sys::ExecutorStart_hook = Some(vectors_executor_start);
+        PREV_PROCESS_UTILITY = pgrx::pg_sys::ProcessUtility_hook;
+        pgrx::pg_sys::ProcessUtility_hook = Some(hook_pgvector_compatibility);
     }
     unsafe {
         pgrx::pg_sys::RegisterXactCallback(Some(xact_callback), std::ptr::null_mut());

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -3,6 +3,7 @@ mod am_build;
 mod am_scan;
 mod am_setup;
 mod am_update;
+mod compat;
 mod hook_executor;
 mod hook_transaction;
 mod hooks;

--- a/tests/sqllogictest/compat.slt
+++ b/tests/sqllogictest/compat.slt
@@ -1,0 +1,107 @@
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+SET vectors.pgvector_compatibility=on;
+
+statement ok
+CREATE TABLE t (val vector(3));
+
+statement ok
+INSERT INTO t (val) SELECT ARRAY[random(), random(), random()]::real[] FROM generate_series(1, 1000);
+
+# HNSW compatible Test
+statement ok
+CREATE INDEX hnsw_l2_index ON t USING hnsw (val vector_l2_ops);
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+DROP INDEX hnsw_l2_index;
+
+statement ok
+CREATE INDEX hnsw_ip_index ON t USING hnsw (val vector_ip_ops) WITH (ef_construction = 80);
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <#> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+DROP INDEX hnsw_ip_index;
+
+statement ok
+CREATE INDEX hnsw_cosine_index ON t USING hnsw (val vector_cosine_ops) WITH (m = 12, ef_construction = 80);
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <=> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+DROP INDEX hnsw_cosine_index;
+
+# IVF compatible Test
+statement ok
+CREATE INDEX ivf_l2_index ON t USING ivfflat (val vector_l2_ops) WITH (lists = 100);
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+DROP INDEX ivf_l2_index;
+
+statement ok
+CREATE INDEX ivf_ip_index ON t USING ivfflat (val vector_ip_ops);
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <#> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+DROP INDEX ivf_ip_index;
+
+statement ok
+CREATE INDEX ivf_cosine_index ON t USING ivfflat (val vector_cosine_ops);
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <=> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+DROP INDEX ivf_cosine_index;
+
+# Native statement
+statement ok
+CREATE INDEX ON t USING vectors (val vector_l2_ops)
+WITH (options = "[indexing.hnsw]");
+
+# Btree index Test - not supported yet
+statement error data type vector has no default operator class for access method "btree"
+CREATE INDEX ON t (val);
+
+statement error could not identify an ordering operator for type vector
+SELECT COUNT(1) FROM (SELECT * FROM t ORDER BY val LIMIT 1) t2;
+
+# Crash Test
+statement error access method "wrong_type" does not exist
+CREATE INDEX ivf_cosine_index ON t USING wrong_type (val vector_cosine_ops);
+
+statement error operator class "wrong_operator" does not exist for access method "vectors"
+CREATE INDEX ivf_cosine_index ON t USING ivfflat (val wrong_operator);
+
+# original statement
+statement ok
+CREATE INDEX ON t USING vectors (val vector_l2_ops)
+WITH (options = "[indexing.hnsw]");
+
+
+statement ok
+DROP TABLE t;


### PR DESCRIPTION
Fix #227 

# Feat
- Add new Gucs `SET vectors.pgvector_compat=on` to enable/disable statement rewrite
- Function `pgvector_compat_rewrite` would be used to edit these elements
  - accessMethod -> from `hnsw/ivfflat` to `vectors`
  - opclass -> from `vector_ip_ops/vector_cosine_ops` to `vector_dot_ops/vector_cos_ops`
  - options -> from `m: int/ef_construction: int/list: int` to `options: serialized toml`
- Test file `compact.slt` for pgvector-style SQL statements

# Examples
These statments would be acceptable from now:
```sql
CREATE INDEX hnsw_l2_index ON t USING hnsw (val vector_l2_ops);
CREATE INDEX hnsw_ip_index ON t USING hnsw (val vector_ip_ops) WITH (ef_construction = 80);
CREATE INDEX hnsw_cosine_index ON t USING hnsw (val vector_cosine_ops) WITH (m = 12, ef_construction = 80);
CREATE INDEX ivf_l2_index ON t USING ivfflat (val vector_l2_ops) WITH (lists = 100);
```

# Limitation
There is still a bit difference at Gucs, including:
- `hnsw.ef_search` at pgvector vs `vectors.hnsw_ef_search` at pgvecto.rs
- `ivfflat.probes` at pgvector vs `vectors.ivf_nporbe` at pgvecto.rs

# Document
* https://github.com/tensorchord/pgvecto.rs-docs/pull/14
