### PR TITLE
feat: Add vector to vecf16 CAST

### DIFF
--- a/src/datatype/casts_f32.rs
+++ b/src/datatype/casts_f32.rs
@@ -1,5 +1,8 @@
 use crate::datatype::typmod::Typmod;
+use crate::datatype::vecf16::{Vecf16, Vecf16Output};
 use crate::datatype::vecf32::{Vecf32, Vecf32Input, Vecf32Output};
+
+use half::f16;
 use service::prelude::*;
 
 #[pgrx::pg_extern(immutable, parallel_safe, strict)]
@@ -27,4 +30,21 @@ fn _vectors_cast_vecf32_to_array(
     _explicit: bool,
 ) -> Vec<f32> {
     vector.data().iter().map(|x| x.to_f32()).collect()
+}
+
+#[pgrx::pg_extern(immutable, parallel_safe, strict)]
+fn _vectors_cast_vecf32_to_vecf16(
+    vector: Vecf32Input<'_>,
+    _typmod: i32,
+    _explicit: bool,
+) -> Vecf16Output {
+    let data: Vec<F16> = vector
+        .data()
+        .iter()
+        .map(|x| x.to_f32())
+        .map(f16::from_f32)
+        .map(F16::from)
+        .collect();
+
+    Vecf16::new_in_postgres(&data)
 }

--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -233,6 +233,9 @@ CREATE CAST (real[] AS vector)
 CREATE CAST (vector AS real[])
     WITH FUNCTION _vectors_cast_vecf32_to_array(vector, integer, boolean) AS IMPLICIT;
 
+CREATE CAST (vector AS vecf16)
+    WITH FUNCTION _vectors_cast_vecf32_to_vecf16(vector, integer, boolean);
+
 -- List of access methods
 
 CREATE ACCESS METHOD vectors TYPE INDEX HANDLER _vectors_amhandler;

--- a/tests/sqllogictest/cast.slt
+++ b/tests/sqllogictest/cast.slt
@@ -105,3 +105,9 @@ query I
 SELECT '{"[1,2,3]"}'::vector[];
 ----
 {"[1, 2, 3]"}
+
+# vector to vecf16
+query I
+SELECT '[1,]'::vector::vecf16;
+----
+[1]


### PR DESCRIPTION
This adds the ability to cast vectors to vecf16.  Partially addressing #255 and closing #262, which specifically requests only this functionality. 