### PR TITLE
fix: prevent overflow at kmeans

### DIFF
--- a/crates/service/src/algorithms/clustering/elkan_k_means.rs
+++ b/crates/service/src/algorithms/clustering/elkan_k_means.rs
@@ -94,7 +94,7 @@ impl<S: G> ElkanKMeans<S> {
         let sorted_index = samples.argsort();
         for i in 0..n {
             let index = sorted_index.get(i).unwrap();
-            let last = sorted_index.get(std::cmp::max(i - 1, 0)).unwrap();
+            let last = sorted_index.get(std::cmp::max(i, 1) - 1).unwrap();
             if *index == 0 || samples[*last] != samples[*index] {
                 centroids[i].copy_from_slice(&samples[*index]);
             } else {

--- a/crates/service/src/utils/vec2.rs
+++ b/crates/service/src/utils/vec2.rs
@@ -22,7 +22,7 @@ impl<S: G> Vec2<S> {
     }
     pub fn argsort(&self) -> Vec<usize> {
         let mut index: Vec<usize> = (0..self.len()).collect();
-        index.sort_by_key(|i| self[*i].to_vec());
+        index.sort_by_key(|i| &self[*i]);
         index
     }
     pub fn copy_within(&mut self, i: usize, j: usize) {

--- a/crates/service/src/utils/vec2.rs
+++ b/crates/service/src/utils/vec2.rs
@@ -20,6 +20,11 @@ impl<S: G> Vec2<S> {
     pub fn len(&self) -> usize {
         self.v.len() / self.dims as usize
     }
+    pub fn argsort(&self) -> Vec<usize> {
+        let mut index: Vec<usize> = (0..self.len()).collect();
+        index.sort_by_key(|i| self[*i].to_vec());
+        index
+    }
     pub fn copy_within(&mut self, i: usize, j: usize) {
         assert!(i < self.len() && j < self.len());
         unsafe {


### PR DESCRIPTION
Thanks to @xieydd , we have digged out this bug.

```rust
Panickied. Info: PanicInfo { payload: Any { .. }, 
message: Some(attempt to subtract with overflow), 
location: Location { file: "crates/service/src/algorithms/clustering/[elkan_k_means.rs](http://elkan_k_means.rs/)", line: 179, col: 47 }, 
can_unwind: true, force_no_backtrace: false }
```
If there is too few vectors with a small count `n` and larger `nlist as c`, it will be a `overflow` there.