### PR TITLE
chore: update the release & nightly action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,9 +19,9 @@ jobs:
           commit_date=$(git log -1 --since="24 hours ago" --pretty=format:"%cI")
           if [[ -n "$commit_date" ]]; then
             if $(gh release view nightly); then
-              gh release edit nightly --target main
+              gh release edit 0.0.0-nightly --target main
             else
-              gh release create nightly --generate-notes --prerelease
+              gh release create 0.0.0-nightly --generate-notes --prerelease
             fi
           fi
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,13 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: |
           commit_date=$(git log -1 --since="24 hours ago" --pretty=format:"%cI")
           if [[ -n "$commit_date" ]]; then
-            gh workflow run release.yml \
-              -f version=$(TZ='Asia/Shanghai' date +"0.0.0-nightly.%Y%m%d") \
-              -f prerelease=true
+            if $(gh release view nightly); then
+              gh release edit nightly --target main
+            else
+              gh release create nightly --generate-notes --prerelease
+            fi
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: v${{ github.event.release.tag_name }}
       - name: Download
-        run: wget -O pgvecto-rs-binary-release.deb https://github.com/tensorchord/pgvecto.rs/releases/download/v${{ github.event.release.tag_name }}/vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download ${{ github.event.release.tag_name }} --pattern "vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb" --output pgvecto-rs-binary-release.deb
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,16 @@ env:
   RUSTC_WRAPPER: sccache
 
 jobs:
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const r = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/;
+            if (!r.test("${{ github.event.release.tag_name }}")) {
+              core.setFailed(`invalid semver`);
+            }
   binary:
     strategy:
       matrix:
@@ -31,6 +41,7 @@ jobs:
           - { version: 16, platform: amd64, arch: x86_64 }
           - { version: 16, platform: arm64, arch: aarch64 }
     runs-on: ubuntu-20.04
+    needs: ["semver"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -140,8 +151,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: v${{ github.event.release.tag_name }}
       - name: Variables
         id: variables
         uses: actions/github-script@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,14 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        type: string
-        description: Version
-        required: true
-      prerelease:
-        type: boolean
-        description: Prerelease
-        required: true
-        default: false
+  release:
+    types:
+      - created
+      - edited
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -23,37 +20,7 @@ env:
   RUSTC_WRAPPER: sccache
 
 jobs:
-  release:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const r = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/;
-            if (!r.test("${{ github.event.inputs.version }}")) {
-              core.setFailed(`Action failed with an invalid semver.`);
-            }
-      - run: |
-          git config --global user.email "support@tensorchord.ai"
-          git config --global user.name "CI[bot]"
-      - run: ./scripts/ci_release.sh
-        env:
-          SEMVER: ${{ github.event.inputs.version }}
-      - id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ github.event.inputs.version }}
-          release_name: v${{ github.event.inputs.version }}
-          draft: false
-          prerelease: ${{ github.event.inputs.prerelease }}
-    outputs:
-      upload_url: ${{ steps.create-release.outputs.upload_url }}
   binary:
-    needs: ["release"]
     strategy:
       matrix:
         include:
@@ -66,9 +33,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: v${{ github.event.inputs.version }}
+        uses: actions/checkout@v4
+      - name: Update release tag
+        run: |
+          sed -i "s/@CARGO_VERSION@/${{ github.event.release.tag_name }}/g" ./vectors.control
       - uses: actions/cache/restore@v3
         with:
           path: |
@@ -110,25 +78,21 @@ jobs:
             --input-type dir \
             --output-type deb \
             --name vectors-pg${{ matrix.version }} \
-            --version ${{ github.event.inputs.version }} \
+            --version ${{ github.event.release.tag_name }} \
             --license apache2 \
             --deb-no-default-config-files \
-            --package ../vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb \
+            --package ../vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb \
             --architecture ${{ matrix.platform }} \
             .
         env:
           VERSION: ${{ matrix.version }}
       - name: Upload Release
-        uses: actions/upload-release-asset@v1
+        run: |
+          gh release upload --clobber ./vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ./vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb
-          asset_name: vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb
-          asset_content_type: application/vnd.debian.binary-package
+          GH_TOKEN: ${{ github.token }}
   docker_binary_release:
-    needs: ["release", "binary"]
+    needs: ["binary"]
     strategy:
       matrix:
         include:
@@ -141,11 +105,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: v${{ github.event.inputs.version }}
+          ref: v${{ github.event.release.tag_name }}
       - name: Download
-        run: wget -O pgvecto-rs-binary-release.deb https://github.com/tensorchord/pgvecto.rs/releases/download/v${{ github.event.inputs.version }}/vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb
+        run: wget -O pgvecto-rs-binary-release.deb https://github.com/tensorchord/pgvecto.rs/releases/download/v${{ github.event.release.tag_name }}/vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -162,7 +126,7 @@ jobs:
           push: true
           platforms: "linux/${{ matrix.platform }}"
           file: ./docker/binary_release.Dockerfile
-          tags: tensorchord/pgvecto-rs-binary:pg${{ matrix.version }}-v${{ github.event.inputs.version }}-${{ matrix.platform }}
+          tags: tensorchord/pgvecto-rs-binary:pg${{ matrix.version }}-v${{ github.event.release.tag_name }}-${{ matrix.platform }}
   docker_release:
     needs: ["docker_binary_release"]
     runs-on: ubuntu-20.04
@@ -174,16 +138,16 @@ jobs:
           - { version: 16 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: v${{ github.event.inputs.version }}
+          ref: v${{ github.event.release.tag_name }}
       - name: Variables
         id: variables
         uses: actions/github-script@v6
         with:
           script: |
             let tags = [
-              "tensorchord/pgvecto-rs:pg${{ matrix.version }}-v${{ github.event.inputs.version }}",
+              "tensorchord/pgvecto-rs:pg${{ matrix.version }}-v${{ github.event.release.tag_name }}",
             ];
             // const actor = context.actor;
             // if (actor != "github-actions[bot]") {
@@ -210,6 +174,6 @@ jobs:
           platforms: "linux/amd64,linux/arm64"
           file: ./docker/pgvecto-rs.Dockerfile
           build-args: |
-            TAG=pg${{ matrix.version }}-v${{ github.event.inputs.version }}
+            TAG=pg${{ matrix.version }}-v${{ github.event.release.tag_name }}
             POSTGRES_VERSION=${{ matrix.version }}
           tags: ${{ steps.variables.outputs.tags }}


### PR DESCRIPTION
- fix #142 

## Changes

- nightly will only have only one release and it will edit this release if there are changes in 24h
- nightly will trigger the release action through an release created/edited event
- release will be triggered with GitHub Release, so we won't be able to push the version change commit to this tag, we only modify the code in the release
- replaces several archived actions with gh cli

## TODO

- generated release note cannot group the PRs since we don't have tags on PRs, otherwise this can be done with a https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options