### PR TITLE
feat: support pgvector gucs compact

### DIFF
--- a/src/gucs/executing.rs
+++ b/src/gucs/executing.rs
@@ -19,7 +19,7 @@ pub unsafe fn init() {
     );
     GucRegistry::define_int_guc(
         "vectors.ivf_nprobe",
-        "`nprobe` argument of HNSW algorithm.",
+        "`nprobe` argument of IVF algorithm.",
         "https://docs.pgvecto.rs/usage/search.html",
         &IVF_NPROBE,
         1,

--- a/src/gucs/executing.rs
+++ b/src/gucs/executing.rs
@@ -18,7 +18,7 @@ pub unsafe fn init() {
         GucFlags::default(),
     );
     GucRegistry::define_int_guc(
-        "vectors.ivf_nporbe",
+        "vectors.ivf_nprobe",
         "`nprobe` argument of HNSW algorithm.",
         "https://docs.pgvecto.rs/usage/search.html",
         &IVF_NPROBE,

--- a/tests/sqllogictest/compact_stmt.slt
+++ b/tests/sqllogictest/compact_stmt.slt
@@ -102,6 +102,5 @@ statement ok
 CREATE INDEX ON t USING vectors (val vector_l2_ops)
 WITH (options = "[indexing.hnsw]");
 
-
 statement ok
 DROP TABLE t;

--- a/tests/sqllogictest/compact_var.slt
+++ b/tests/sqllogictest/compact_var.slt
@@ -1,0 +1,93 @@
+statement ok
+SET vectors.pgvector_compatibility=off;
+
+query I
+SHOW vectors.pgvector_compatibility;
+----
+off
+
+statement ok
+SET ivfflat.probes=40;
+
+query I
+SHOW vectors.ivf_nprobe;
+----
+10
+
+query I
+SHOW ivfflat.probes;
+----
+40
+
+statement ok
+SET hnsw.ef_search=400;
+
+query I
+SHOW vectors.hnsw_ef_search;
+----
+100
+
+query I
+SHOW hnsw.ef_search;
+----
+400
+
+statement ok
+SET vectors.pgvector_compatibility=on;
+
+query I
+SHOW vectors.pgvector_compatibility;
+----
+on
+
+statement ok
+SET ivfflat.probes=50;
+
+query I
+SHOW vectors.ivf_nprobe;
+----
+50
+
+query I
+SHOW ivfflat.probes;
+----
+50
+
+statement ok
+SET hnsw.ef_search=500;
+
+query I
+SHOW vectors.hnsw_ef_search;
+----
+500
+
+query I
+SHOW hnsw.ef_search;
+----
+500
+
+statement ok
+SET ivfflat.probes=60;
+
+query I
+SHOW vectors.ivf_nprobe;
+----
+60
+
+query I
+SHOW ivfflat.probes;
+----
+60
+
+statement ok
+SET vectors.hnsw_ef_search=600;
+
+query I
+SHOW vectors.hnsw_ef_search;
+----
+600
+
+query I
+SHOW hnsw.ef_search;
+----
+600


### PR DESCRIPTION
Fix #295 
Related to #256 and #227
From now, we support `vectors.ivf_nprobe` and `vectors.hnsw_ef_search` like `pgvector` through overwrite.
However, their default value is not the same as pgvector.

# Document
* https://github.com/tensorchord/pgvecto.rs-docs/pull/14

