### PR TITLE
chore: nightly token that can trigger the release workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,13 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: |
           commit_date=$(git log -1 --since="24 hours ago" --pretty=format:"%cI")
           if [[ -n "$commit_date" ]]; then
-            gh workflow run release.yml \
-              -f version=$(TZ='Asia/Shanghai' date +"0.0.0-nightly.%Y%m%d") \
-              -f prerelease=true
+            if $(gh release view nightly); then
+              gh release edit 0.0.0-nightly --target main
+            else
+              gh release create 0.0.0-nightly --generate-notes --prerelease
+            fi
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,23 +6,22 @@ on:
     - cron: "0 16 * * *"
   workflow_dispatch:
 
-permissions:
-  actions: write
-
 jobs:
   setup:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.NIGHTLY_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - run: |
           commit_date=$(git log -1 --since="24 hours ago" --pretty=format:"%cI")
           if [[ -n "$commit_date" ]]; then
-            if $(gh release view nightly); then
-              gh release edit 0.0.0-nightly --target main
+            if $(gh release view v0.0.0-nightly); then
+              gh release edit v0.0.0-nightly --target main
             else
-              gh release create 0.0.0-nightly --generate-notes --prerelease
+              gh release create v0.0.0-nightly --generate-notes --prerelease
             fi
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,14 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        type: string
-        description: Version
-        required: true
-      prerelease:
-        type: boolean
-        description: Prerelease
-        required: true
-        default: false
+  release:
+    types:
+      - created
+      - edited
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -23,37 +20,17 @@ env:
   RUSTC_WRAPPER: sccache
 
 jobs:
-  release:
-    runs-on: ubuntu-20.04
+  semver:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - uses: actions/github-script@v7
         with:
           script: |
             const r = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/;
-            if (!r.test("${{ github.event.inputs.version }}")) {
-              core.setFailed(`Action failed with an invalid semver.`);
+            if (!r.test("${{ github.event.release.tag_name }}")) {
+              core.setFailed(`invalid semver`);
             }
-      - run: |
-          git config --global user.email "support@tensorchord.ai"
-          git config --global user.name "CI[bot]"
-      - run: ./scripts/ci_release.sh
-        env:
-          SEMVER: ${{ github.event.inputs.version }}
-      - id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ github.event.inputs.version }}
-          release_name: v${{ github.event.inputs.version }}
-          draft: false
-          prerelease: ${{ github.event.inputs.prerelease }}
-    outputs:
-      upload_url: ${{ steps.create-release.outputs.upload_url }}
   binary:
-    needs: ["release"]
     strategy:
       matrix:
         include:
@@ -64,11 +41,13 @@ jobs:
           - { version: 16, platform: amd64, arch: x86_64 }
           - { version: 16, platform: arm64, arch: aarch64 }
     runs-on: ubuntu-20.04
+    needs: ["semver"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: v${{ github.event.inputs.version }}
+        uses: actions/checkout@v4
+      - name: Update release tag
+        run: |
+          sed -i "s/@CARGO_VERSION@/${{ github.event.release.tag_name }}/g" ./vectors.control
       - uses: actions/cache/restore@v3
         with:
           path: |
@@ -110,25 +89,21 @@ jobs:
             --input-type dir \
             --output-type deb \
             --name vectors-pg${{ matrix.version }} \
-            --version ${{ github.event.inputs.version }} \
+            --version ${{ github.event.release.tag_name }} \
             --license apache2 \
             --deb-no-default-config-files \
-            --package ../vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb \
+            --package ../vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb \
             --architecture ${{ matrix.platform }} \
             .
         env:
           VERSION: ${{ matrix.version }}
       - name: Upload Release
-        uses: actions/upload-release-asset@v1
+        run: |
+          gh release upload --clobber ./vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ./vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb
-          asset_name: vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb
-          asset_content_type: application/vnd.debian.binary-package
+          GH_TOKEN: ${{ github.token }}
   docker_binary_release:
-    needs: ["release", "binary"]
+    needs: ["binary"]
     strategy:
       matrix:
         include:
@@ -141,11 +116,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: v${{ github.event.inputs.version }}
+        uses: actions/checkout@v4
       - name: Download
-        run: wget -O pgvecto-rs-binary-release.deb https://github.com/tensorchord/pgvecto.rs/releases/download/v${{ github.event.inputs.version }}/vectors-pg${{ matrix.version }}_${{ github.event.inputs.version }}_${{ matrix.platform }}.deb
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download ${{ github.event.release.tag_name }} --pattern "vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb" --output pgvecto-rs-binary-release.deb
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -162,7 +138,7 @@ jobs:
           push: true
           platforms: "linux/${{ matrix.platform }}"
           file: ./docker/binary_release.Dockerfile
-          tags: tensorchord/pgvecto-rs-binary:pg${{ matrix.version }}-v${{ github.event.inputs.version }}-${{ matrix.platform }}
+          tags: tensorchord/pgvecto-rs-binary:pg${{ matrix.version }}-v${{ github.event.release.tag_name }}-${{ matrix.platform }}
   docker_release:
     needs: ["docker_binary_release"]
     runs-on: ubuntu-20.04
@@ -174,16 +150,14 @@ jobs:
           - { version: 16 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: v${{ github.event.inputs.version }}
+        uses: actions/checkout@v4
       - name: Variables
         id: variables
         uses: actions/github-script@v6
         with:
           script: |
             let tags = [
-              "tensorchord/pgvecto-rs:pg${{ matrix.version }}-v${{ github.event.inputs.version }}",
+              "tensorchord/pgvecto-rs:pg${{ matrix.version }}-v${{ github.event.release.tag_name }}",
             ];
             // const actor = context.actor;
             // if (actor != "github-actions[bot]") {
@@ -210,6 +184,6 @@ jobs:
           platforms: "linux/amd64,linux/arm64"
           file: ./docker/pgvecto-rs.Dockerfile
           build-args: |
-            TAG=pg${{ matrix.version }}-v${{ github.event.inputs.version }}
+            TAG=pg${{ matrix.version }}-v${{ github.event.release.tag_name }}
             POSTGRES_VERSION=${{ matrix.version }}
           tags: ${{ steps.variables.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
   docker_binary_release:
-    needs: ["binary"]
+    needs: ["binary", "semver"]
     strategy:
       matrix:
         include:
@@ -147,7 +147,7 @@ jobs:
           file: ./docker/binary_release.Dockerfile
           tags: tensorchord/pgvecto-rs-binary:pg${{ matrix.version }}-v${{ needs.semver.outputs.version }}-${{ matrix.platform }}
   docker_release:
-    needs: ["docker_binary_release"]
+    needs: ["docker_binary_release", "semver"]
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           VERSION: ${{ matrix.version }}
       - name: Upload Release
         run: |
-          gh release upload --clobber ./vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb
+          gh release upload --clobber ${{ github.event.release.tag_name }} ./vectors-pg${{ matrix.version }}_${{ github.event.release.tag_name }}_${{ matrix.platform }}.deb
         env:
           GH_TOKEN: ${{ github.token }}
   docker_binary_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ env:
 jobs:
   semver:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.semver }}
     steps:
       - uses: actions/github-script@v7
         id: version
@@ -34,9 +36,6 @@ jobs:
             const matches = "${{ github.event.release.tag_name }}".match(r);
             console.log(matches);
             core.setOutput('semver', matches[0]);
-      - run: |
-          echo ${{ steps.version.outputs.semver }}
-          exit 1
   binary:
     strategy:
       matrix:
@@ -54,7 +53,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Update release tag
         run: |
-          sed -i "s/@CARGO_VERSION@/${{ steps.version.outputs.semver }}/g" ./vectors.control
+          sed -i "s/@CARGO_VERSION@/${{ needs.semver.outputs.version }}/g" ./vectors.control
+          cat ./vectors.control
       - uses: actions/cache/restore@v3
         with:
           path: |
@@ -96,17 +96,17 @@ jobs:
             --input-type dir \
             --output-type deb \
             --name vectors-pg${{ matrix.version }} \
-            --version ${{ steps.version.outputs.semver }} \
+            --version ${{ needs.semver.outputs.version }} \
             --license apache2 \
             --deb-no-default-config-files \
-            --package ../vectors-pg${{ matrix.version }}_${{ steps.version.outputs.semver }}_${{ matrix.platform }}.deb \
+            --package ../vectors-pg${{ matrix.version }}_${{ needs.semver.outputs.version }}_${{ matrix.platform }}.deb \
             --architecture ${{ matrix.platform }} \
             .
         env:
           VERSION: ${{ matrix.version }}
       - name: Upload Release
         run: |
-          gh release upload --clobber ${{ github.event.release.tag_name }} ./vectors-pg${{ matrix.version }}_${{ steps.version.outputs.semver }}_${{ matrix.platform }}.deb
+          gh release upload --clobber ${{ github.event.release.tag_name }} ./vectors-pg${{ matrix.version }}_${{ needs.semver.outputs.version }}_${{ matrix.platform }}.deb
         env:
           GH_TOKEN: ${{ github.token }}
   docker_binary_release:
@@ -128,7 +128,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download ${{ github.event.release.tag_name }} --pattern "vectors-pg${{ matrix.version }}_${{ steps.version.outputs.semver }}_${{ matrix.platform }}.deb" --output pgvecto-rs-binary-release.deb
+          gh release download ${{ github.event.release.tag_name }} --pattern "vectors-pg${{ matrix.version }}_${{ needs.semver.outputs.version }}_${{ matrix.platform }}.deb" --output pgvecto-rs-binary-release.deb
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -145,7 +145,7 @@ jobs:
           push: true
           platforms: "linux/${{ matrix.platform }}"
           file: ./docker/binary_release.Dockerfile
-          tags: tensorchord/pgvecto-rs-binary:pg${{ matrix.version }}-v${{ steps.version.outputs.semver }}-${{ matrix.platform }}
+          tags: tensorchord/pgvecto-rs-binary:pg${{ matrix.version }}-v${{ needs.semver.outputs.version }}-${{ matrix.platform }}
   docker_release:
     needs: ["docker_binary_release"]
     runs-on: ubuntu-20.04
@@ -164,7 +164,7 @@ jobs:
         with:
           script: |
             let tags = [
-              "tensorchord/pgvecto-rs:pg${{ matrix.version }}-v${{ steps.version.outputs.semver }}",
+              "tensorchord/pgvecto-rs:pg${{ matrix.version }}-v${{ needs.semver.outputs.version }}",
             ];
             // const actor = context.actor;
             // if (actor != "github-actions[bot]") {
@@ -191,6 +191,6 @@ jobs:
           platforms: "linux/amd64,linux/arm64"
           file: ./docker/pgvecto-rs.Dockerfile
           build-args: |
-            TAG=pg${{ matrix.version }}-v${{ steps.version.outputs.semver }}
+            TAG=pg${{ matrix.version }}-v${{ needs.semver.outputs.version }}
             POSTGRES_VERSION=${{ matrix.version }}
           tags: ${{ steps.variables.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,11 @@ jobs:
               core.setFailed(`invalid semver`);
             }
             const matches = "${{ github.event.release.tag_name }}".match(r);
+            console.log(matches);
             core.setOutput('semver', matches[0]);
+      - run: |
+          echo ${{ steps.version.outputs.semver }}
+          exit 1
   binary:
     strategy:
       matrix:


### PR DESCRIPTION
- align the nightly tag
- change to a nightly token that has permission to trigger another workflow

According to the GitHub [trigger a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), the default `GITHUB_TOKEN` cannot trigger another workflow. Thus it requires a personal access token.

You can follow the instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) to generate a repository level token and save it to this repo setting with the name `NIGHTLY_TOKEN`. It requires the following read/write permission:
- actions
- contents

cc @VoVAllen 