### PR TITLE
chore: set storage = EXTERNAL by default for vector types

### DIFF
--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -7,7 +7,7 @@ CREATE TYPE vector (
     OUTPUT = _vectors_vecf32_out,
     TYPMOD_IN = _vectors_typmod_in,
     TYPMOD_OUT = _vectors_typmod_out,
-    STORAGE = EXTENDED,
+    STORAGE = EXTERNAL,
     INTERNALLENGTH = VARIABLE,
     ALIGNMENT = double
 );
@@ -17,7 +17,7 @@ CREATE TYPE vecf16 (
     OUTPUT = _vectors_vecf16_out,
     TYPMOD_IN = _vectors_typmod_in,
     TYPMOD_OUT = _vectors_typmod_out,
-    STORAGE = EXTENDED,
+    STORAGE = EXTERNAL,
     INTERNALLENGTH = VARIABLE,
     ALIGNMENT = double
 );

--- a/tests/sqllogictest/vecf16_storage.slt
+++ b/tests/sqllogictest/vecf16_storage.slt
@@ -1,0 +1,20 @@
+statement ok
+SET search_path TO pg_temp, vectors;
+
+statement ok
+CREATE TABLE t (val vecf16);
+
+statement ok
+INSERT INTO t (val) SELECT ARRAY[random(), random(), random()]::real[]::vector::vecf16 FROM generate_series(1, 1000);
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE PLAIN;
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE EXTERNAL;
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE EXTENDED;
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE MAIN;

--- a/tests/sqllogictest/vector_storage.slt
+++ b/tests/sqllogictest/vector_storage.slt
@@ -1,0 +1,20 @@
+statement ok
+SET search_path TO pg_temp, vectors;
+
+statement ok
+CREATE TABLE t (val vector);
+
+statement ok
+INSERT INTO t (val) SELECT ARRAY[random(), random(), random()]::real[] FROM generate_series(1, 1000);
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE PLAIN;
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE EXTERNAL;
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE EXTENDED;
+
+statement ok
+ALTER TABLE t ALTER COLUMN val SET STORAGE MAIN;


### PR DESCRIPTION
Pref result shows PostgreSQL compression affects insertion performance largely so we disable it.

Bench code and result: https://gist.github.com/usamoi/ce1b8a9fd806dcca2bcea438b2fdffa2 (based on #314)