### PR TITLE
chore: consistent slice behavior with Python

### DIFF
--- a/src/datatype/vecf16.rs
+++ b/src/datatype/vecf16.rs
@@ -399,7 +399,12 @@ fn _vectors_vecf16_subscript(_fcinfo: pgrx::pg_sys::FunctionCallInfo) -> Datum {
                 if state.upperprovided.read() {
                     if !state.upperindexnull.read() {
                         let upper = state.upperindex.read().value() as i32;
-                        end = Some(upper as usize);
+                        if upper >= 0 {
+                            end = Some(upper as usize);
+                        } else {
+                            (*op).resnull.write(true);
+                            return false;
+                        }
                     } else {
                         (*op).resnull.write(true);
                         return false;
@@ -408,7 +413,12 @@ fn _vectors_vecf16_subscript(_fcinfo: pgrx::pg_sys::FunctionCallInfo) -> Datum {
                 if state.lowerprovided.read() {
                     if !state.lowerindexnull.read() {
                         let lower = state.lowerindex.read().value() as i32;
-                        start = Some((lower - 1) as usize);
+                        if lower >= 0 {
+                            start = Some(lower as usize);
+                        } else {
+                            (*op).resnull.write(true);
+                            return false;
+                        }
                     } else {
                         (*op).resnull.write(true);
                         return false;

--- a/src/datatype/vecf32.rs
+++ b/src/datatype/vecf32.rs
@@ -399,7 +399,12 @@ fn _vectors_vecf32_subscript(_fcinfo: pgrx::pg_sys::FunctionCallInfo) -> Datum {
                 if state.upperprovided.read() {
                     if !state.upperindexnull.read() {
                         let upper = state.upperindex.read().value() as i32;
-                        end = Some(upper as usize);
+                        if upper >= 0 {
+                            end = Some(upper as usize);
+                        } else {
+                            (*op).resnull.write(true);
+                            return false;
+                        }
                     } else {
                         (*op).resnull.write(true);
                         return false;
@@ -408,7 +413,12 @@ fn _vectors_vecf32_subscript(_fcinfo: pgrx::pg_sys::FunctionCallInfo) -> Datum {
                 if state.lowerprovided.read() {
                     if !state.lowerindexnull.read() {
                         let lower = state.lowerindex.read().value() as i32;
-                        start = Some((lower - 1) as usize);
+                        if lower >= 0 {
+                            start = Some(lower as usize);
+                        } else {
+                            (*op).resnull.write(true);
+                            return false;
+                        }
                     } else {
                         (*op).resnull.write(true);
                         return false;

--- a/tests/sqllogictest/pg14/vecf16_subscript.slt
+++ b/tests/sqllogictest/pg14/vecf16_subscript.slt
@@ -2,72 +2,72 @@ statement ok
 SET search_path TO pg_temp, vectors;
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[3:6];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[3:6];
 ----
-[3, 4, 5, 6]
+[3, 4, 5]
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[:4];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[:4];
 ----
-[1, 2, 3, 4]
+[0, 1, 2, 3]
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[5:];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[5:];
 ----
-[5, 6, 7, 8]
+[5, 6, 7]
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[1:8];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[1:8];
 ----
-[1, 2, 3, 4, 5, 6, 7, 8]
+[1, 2, 3, 4, 5, 6, 7]
 
 statement error type vecf16 does only support one subscript
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[3:3][1:1];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[3:3][1:1];
 
 statement error type vecf16 does only support slice fetch
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[3];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[3];
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[5:4];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[5:4];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[9:];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[9:];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[:0];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[:0];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[:-1];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[:-1];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[NULL:NULL];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[NULL:NULL];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[NULL:8];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[NULL:8];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[1:NULL];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[1:NULL];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[NULL:];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[NULL:];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vecf16)[:NULL];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vecf16)[:NULL];
 ----
 NULL

--- a/tests/sqllogictest/pg14/vector_subscript.slt
+++ b/tests/sqllogictest/pg14/vector_subscript.slt
@@ -2,72 +2,72 @@ statement ok
 SET search_path TO pg_temp, vectors;
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[3:6];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[3:6];
 ----
-[3, 4, 5, 6]
+[3, 4, 5]
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[:4];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[:4];
 ----
-[1, 2, 3, 4]
+[0, 1, 2, 3]
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[5:];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[5:];
 ----
-[5, 6, 7, 8]
+[5, 6, 7]
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[1:8];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[1:8];
 ----
-[1, 2, 3, 4, 5, 6, 7, 8]
+[1, 2, 3, 4, 5, 6, 7]
 
 statement error type vector does only support one subscript
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[3:3][1:1];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[3:3][1:1];
 
 statement error type vector does only support slice fetch
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[3];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[3];
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[5:4];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[5:4];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[9:];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[9:];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[:0];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[:0];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[:-1];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[:-1];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[NULL:NULL];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[NULL:NULL];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[NULL:8];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[NULL:8];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[1:NULL];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[1:NULL];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[NULL:];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[NULL:];
 ----
 NULL
 
 query I
-SELECT ('[1, 2, 3, 4, 5, 6, 7, 8]'::vector)[:NULL];
+SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[:NULL];
 ----
 NULL


### PR DESCRIPTION
Current subslice behavior is consistent with PostgreSQL:

```
SELECT ('{0, 1, 2, 3, 4, 5, 6, 7}'::real[])[3:6];
  float4   
-----------
 {2,3,4,5}
(1 row)

SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[3:6];
  vector   
-----------
 [2, 3, 4, 5]
(1 row)
```

Making it consistent with Python should be better.


```
>>> [0, 1, 2, 3, 4, 5, 6, 7][3:6]
[3, 4, 5]

SELECT ('[0, 1, 2, 3, 4, 5, 6, 7]'::vector)[3:6];
  vector   
-----------
 [3, 4, 5]
(1 row)
```