### PR TITLE
fix: support null insert (#390)

### DIFF
--- a/src/index/am.rs
+++ b/src/index/am.rs
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn aminsert(
 pub unsafe extern "C" fn aminsert(
     index_relation: pgrx::pg_sys::Relation,
     values: *mut Datum,
-    _is_null: *mut bool,
+    is_null: *mut bool,
     heap_tid: pgrx::pg_sys::ItemPointer,
     _heap_relation: pgrx::pg_sys::Relation,
     _check_unique: pgrx::pg_sys::IndexUniqueCheck,
@@ -224,8 +224,10 @@ pub unsafe extern "C" fn aminsert(
     #[cfg(feature = "pg16")]
     let oid = (*index_relation).rd_locator.relNumber;
     let id = Handle::from_sys(oid);
-    let vector = from_datum(*values.add(0));
-    am_update::update_insert(id, vector, *heap_tid);
+    let vector = from_datum(*values.add(0), *is_null.add(0));
+    if let Some(v) = vector {
+        am_update::update_insert(id, v, *heap_tid);
+    }
     true
 }
 

--- a/src/index/am_build.rs
+++ b/src/index/am_build.rs
@@ -70,17 +70,25 @@ unsafe extern "C" fn callback(
     index_relation: pgrx::pg_sys::Relation,
     ctid: pgrx::pg_sys::ItemPointer,
     values: *mut pgrx::pg_sys::Datum,
-    _is_null: *mut bool,
+    is_null: *mut bool,
     _tuple_is_alive: bool,
     state: *mut std::os::raw::c_void,
 ) {
+    let state = &mut *(state as *mut Builder);
+    if *is_null.add(0) {
+        (*state.result).heap_tuples += 1.0;
+        return;
+    }
     #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
     let oid = (*index_relation).rd_node.relNode;
     #[cfg(feature = "pg16")]
     let oid = (*index_relation).rd_locator.relNumber;
     let id = Handle::from_sys(oid);
-    let state = &mut *(state as *mut Builder);
-    let vector = from_datum(*values.add(0));
+    let vector = from_datum(*values.add(0), *is_null.add(0));
+    let vector = match vector {
+        Some(v) => v,
+        None => unreachable!(),
+    };
     let pointer = Pointer::from_sys(*ctid);
     state.rpc.insert(id, vector, pointer);
     (*state.result).heap_tuples += 1.0;

--- a/src/index/am_scan.rs
+++ b/src/index/am_scan.rs
@@ -7,6 +7,7 @@ use crate::index::utils::from_datum;
 use crate::ipc::client::ClientGuard;
 use crate::ipc::client::{Basic, Vbase};
 use crate::prelude::*;
+use pgrx::pg_sys::SK_ISNULL;
 use pgrx::FromDatum;
 use service::prelude::*;
 
@@ -62,15 +63,15 @@ pub unsafe fn make_scan(index_relation: pgrx::pg_sys::Relation) -> pgrx::pg_sys:
 
 pub unsafe fn start_scan(scan: pgrx::pg_sys::IndexScanDesc, orderbys: pgrx::pg_sys::ScanKey) {
     std::ptr::copy(orderbys, (*scan).orderByData, 1);
-
-    let vector = from_datum((*orderbys.add(0)).sk_argument);
+    let is_null = (SK_ISNULL & (*orderbys.add(0)).sk_flags as u32) != 0;
+    let vector = from_datum((*orderbys.add(0)).sk_argument, is_null);
 
     let scanner = &mut *((*scan).opaque as *mut Scanner);
     let scanner = std::mem::replace(
         scanner,
         Scanner::Initial {
             node: scanner.node(),
-            vector: Some(vector),
+            vector,
         },
     );
 

--- a/tests/sqllogictest/null.slt
+++ b/tests/sqllogictest/null.slt
@@ -1,0 +1,40 @@
+statement ok
+SET search_path TO pg_temp, vectors;
+
+statement ok
+CREATE TABLE t (val vector(3));
+
+statement ok
+INSERT INTO t (val) SELECT ARRAY[random(), random(), random()]::real[] FROM generate_series(1, 100);
+
+statement ok
+INSERT INTO t (val) SELECT ('[NaN, Infinity, -Infinity]') FROM generate_series(1, 100);
+
+statement ok
+INSERT INTO t (val) SELECT (NULL) FROM generate_series(1, 100);
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+CREATE INDEX hnsw_index ON t USING vectors (val vector_l2_ops)
+WITH (options = "[indexing.hnsw]");
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+REINDEX INDEX hnsw_index;
+
+query I
+SELECT COUNT(1) FROM (SELECT 1 FROM t ORDER BY val <-> '[0.5,0.5,0.5]' limit 10) t2;
+----
+10
+
+statement ok
+----
+DROP TABLE t;


### PR DESCRIPTION
cherry pick of #390 

We still need to upgrade some of docs at https://docs.pgvecto.rs/admin/upgrading.html as:
- Delete existing index at NULL-possible column to avoid crash
- Take `kubectl delete pod/kubectl rollout restart` instead of `kubectl cnpg restart` to avoid #387