### PR TITLE
fix: remove sighup handler

### DIFF
--- a/src/bgworker/normal.rs
+++ b/src/bgworker/normal.rs
@@ -41,12 +41,12 @@ pub fn normal(worker: Arc<Worker>) {
             unsafe {
                 let mut set: libc::sigset_t = std::mem::zeroed();
                 libc::sigemptyset(&mut set);
-                libc::sigaddset(&mut set, libc::SIGHUP);
+                libc::sigaddset(&mut set, libc::SIGQUIT);
                 libc::sigaddset(&mut set, libc::SIGTERM);
                 libc::sigwait(&set, &mut sig);
             }
             match sig {
-                libc::SIGHUP => {
+                libc::SIGQUIT => {
                     std::process::exit(0);
                 }
                 libc::SIGTERM => {


### PR DESCRIPTION
Fix #387 

SIGTERM and SIGQUIT are used at postgres shutdown
https://www.postgresql.org/docs/current/server-shutdown.html