### PR TITLE
fix: bvector subscription may modify padding bits 

### DIFF
--- a/src/datatype/subscript_bvecf32.rs
+++ b/src/datatype/subscript_bvecf32.rs
@@ -170,7 +170,9 @@ fn _vectors_bvecf32_subscript(_fcinfo: pgrx::pg_sys::FunctionCallInfo) -> Datum 
                     let end_idx = (end as usize).div_ceil(BVEC_WIDTH);
                     let slice = values.data_mut();
                     slice.copy_from_slice(&input.for_borrow().data()[start_idx..end_idx]);
-                    slice[end_idx - start_idx - 1] &= (1 << (end as usize % BVEC_WIDTH)) - 1;
+                    if end as usize % BVEC_WIDTH != 0 {
+                        slice[end_idx - start_idx - 1] &= (1 << (end as usize % BVEC_WIDTH)) - 1;
+                    }
                 } else {
                     let mut i = 0;
                     let mut j = start as usize;

--- a/src/datatype/subscript_bvecf32.rs
+++ b/src/datatype/subscript_bvecf32.rs
@@ -168,9 +168,10 @@ fn _vectors_bvecf32_subscript(_fcinfo: pgrx::pg_sys::FunctionCallInfo) -> Datum 
                 if start % BVEC_WIDTH as u16 == 0 {
                     let start_idx = start as usize / BVEC_WIDTH;
                     let end_idx = (end as usize).div_ceil(BVEC_WIDTH);
-                    values
-                        .data_mut()
-                        .copy_from_slice(&input.for_borrow().data()[start_idx..end_idx]);
+                    let slice = values.data_mut();
+                    slice.copy_from_slice(&input.for_borrow().data()[start_idx..end_idx]);
+                    slice[(end_idx - start_idx - 1) as usize] &=
+                        (1 << (end as usize % BVEC_WIDTH)) - 1;
                 } else {
                     let mut i = 0;
                     let mut j = start as usize;

--- a/src/datatype/subscript_bvecf32.rs
+++ b/src/datatype/subscript_bvecf32.rs
@@ -170,8 +170,7 @@ fn _vectors_bvecf32_subscript(_fcinfo: pgrx::pg_sys::FunctionCallInfo) -> Datum 
                     let end_idx = (end as usize).div_ceil(BVEC_WIDTH);
                     let slice = values.data_mut();
                     slice.copy_from_slice(&input.for_borrow().data()[start_idx..end_idx]);
-                    slice[(end_idx - start_idx - 1) as usize] &=
-                        (1 << (end as usize % BVEC_WIDTH)) - 1;
+                    slice[end_idx - start_idx - 1] &= (1 << (end as usize % BVEC_WIDTH)) - 1;
                 } else {
                     let mut i = 0;
                     let mut j = start as usize;

--- a/tests/sqllogictest/bvector_subscript.slt
+++ b/tests/sqllogictest/bvector_subscript.slt
@@ -71,3 +71,8 @@ query I
 SELECT ('[0, 1, 0, 1, 0, 1, 0, 1]'::bvector)[:NULL];
 ----
 NULL
+
+query I
+SELECT ((replace(replace(array_agg(1)::real[]::text, '{', '['), '}', ']')::bvector)[:])[:2] FROM generate_series(1, 64);
+----
+[1, 1]


### PR DESCRIPTION
Sorry. I forget to consider the situation of `end % BVEC_WIDTH == 0`.