### PR TITLE
fix: validate_index for veci8 & rm deprecated feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ half = { version = "2.4.0", features = [
     "num-traits",
     "rand_distr",
     "serde",
-    "use-intrinsics",
 ] }
 libc = "0.2.153"
 log = "0.4.21"

--- a/crates/base/src/index.rs
+++ b/crates/base/src/index.rs
@@ -127,7 +127,10 @@ pub struct IndexOptions {
 
 impl IndexOptions {
     fn validate_index_options(options: &IndexOptions) -> Result<(), ValidationError> {
-        if options.vector.v != VectorKind::SVecf32 && options.vector.v != VectorKind::BVecf32 {
+        if options.vector.v != VectorKind::SVecf32
+            && options.vector.v != VectorKind::BVecf32
+            && options.vector.v != VectorKind::Veci8
+        {
             return Ok(());
         }
         let is_trivial = match &options.indexing {
@@ -137,7 +140,7 @@ impl IndexOptions {
         };
         if !is_trivial {
             return Err(ValidationError::new(
-                "Quantization is not supported for svector and bvector.",
+                "Quantization is not supported for svector, bvector, and vecint8.",
             ));
         }
         Ok(())


### PR DESCRIPTION
I found that IndexOption check for vecint8 is lost when I merge branch.