### PR TITLE
fix: fix openai option gucs setting.

### DIFF
--- a/src/gucs/embedding.rs
+++ b/src/gucs/embedding.rs
@@ -4,7 +4,7 @@ use pgrx::{GucContext, GucFlags, GucRegistry, GucSetting};
 use std::ffi::CStr;
 
 pub fn openai_options() -> OpenAIOptions {
-    let base_url = guc_string_parse(&OPENAI_BASE_URL, "vectors.openai_base");
+    let base_url = guc_string_parse(&OPENAI_BASE_URL, "vectors.openai_base_url");
     let api_key = guc_string_parse(&OPENAI_API_KEY, "vectors.openai_api_key");
     OpenAIOptions { base_url, api_key }
 }
@@ -13,7 +13,7 @@ static OPENAI_API_KEY: GucSetting<Option<&'static CStr>> =
     GucSetting::<Option<&'static CStr>>::new(None);
 
 static OPENAI_BASE_URL: GucSetting<Option<&'static CStr>> =
-    GucSetting::<Option<&'static CStr>>::new(Some(c"https://api.openai.com/v1/"));
+    GucSetting::<Option<&'static CStr>>::new(Some(c"https://api.openai.com/v1"));
 
 pub unsafe fn init() {
     GucRegistry::define_string_guc(

--- a/tests/sqllogictest/openai_options.slt
+++ b/tests/sqllogictest/openai_options.slt
@@ -1,0 +1,18 @@
+statement ok
+SET search_path TO pg_temp, vectors;
+
+statement ok
+SET vectors.openai_base_url TO 'https://api.moonshot.cn/v1';
+
+statement ok
+SET vectors.openai_api_key TO 'fake_key';
+
+query ?
+SHOW vectors.openai_base_url;
+----
+https://api.moonshot.cn/v1
+
+query ?
+SHOW vectors.openai_api_key;
+----
+fake_key


### PR DESCRIPTION
I think those code don't matchs.
```rust     
let base_url = guc_string_parse(&OPENAI_BASE_URL, "vectors.openai_base");
```
and 

```rust
    GucRegistry::define_string_guc(
        "vectors.openai_base_url",
        "The base url of OpenAI or compatible server.",
        "",
        &OPENAI_BASE_URL,
        GucContext::Userset,
        GucFlags::default(),
    );
```