### PR TITLE
feat: make schema mutable in compile time

### DIFF
--- a/src/datatype/memory_bvecf32.rs
+++ b/src/datatype/memory_bvecf32.rs
@@ -13,6 +13,8 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ptr::NonNull;
 
+use crate::schema::pgvectors_schema_cstr;
+
 #[repr(C, align(8))]
 pub struct BVecf32Header {
     varlena: u32,
@@ -143,7 +145,8 @@ impl IntoDatum for BVecf32Output {
     }
 
     fn type_oid() -> Oid {
-        let namespace = pgrx::pg_catalog::PgNamespace::search_namespacename(c"vectors").unwrap();
+        let namespace =
+            pgrx::pg_catalog::PgNamespace::search_namespacename(&pgvectors_schema_cstr()).unwrap();
         let namespace = namespace.get().expect("pgvecto.rs is not installed.");
         let t = pgrx::pg_catalog::PgType::search_typenamensp(c"bvector", namespace.oid()).unwrap();
         let t = t.get().expect("pg_catalog is broken.");

--- a/src/datatype/memory_svecf32.rs
+++ b/src/datatype/memory_svecf32.rs
@@ -1,3 +1,4 @@
+use crate::schema::pgvectors_schema_cstr;
 use base::scalar::*;
 use base::vector::*;
 use pgrx::pg_sys::Datum;
@@ -159,7 +160,8 @@ impl IntoDatum for SVecf32Output {
     }
 
     fn type_oid() -> Oid {
-        let namespace = pgrx::pg_catalog::PgNamespace::search_namespacename(c"vectors").unwrap();
+        let namespace =
+            pgrx::pg_catalog::PgNamespace::search_namespacename(&pgvectors_schema_cstr()).unwrap();
         let namespace = namespace.get().expect("pgvecto.rs is not installed.");
         let t = pgrx::pg_catalog::PgType::search_typenamensp(c"svector", namespace.oid()).unwrap();
         let t = t.get().expect("pg_catalog is broken.");

--- a/src/datatype/memory_vecf16.rs
+++ b/src/datatype/memory_vecf16.rs
@@ -13,6 +13,8 @@ use std::alloc::Layout;
 use std::ops::Deref;
 use std::ptr::NonNull;
 
+use crate::schema::pgvectors_schema_cstr;
+
 #[repr(C, align(8))]
 pub struct Vecf16Header {
     varlena: u32,
@@ -136,7 +138,8 @@ impl IntoDatum for Vecf16Output {
     }
 
     fn type_oid() -> Oid {
-        let namespace = pgrx::pg_catalog::PgNamespace::search_namespacename(c"vectors").unwrap();
+        let namespace =
+            pgrx::pg_catalog::PgNamespace::search_namespacename(&pgvectors_schema_cstr()).unwrap();
         let namespace = namespace.get().expect("pgvecto.rs is not installed.");
         let t = pgrx::pg_catalog::PgType::search_typenamensp(c"vecf16", namespace.oid()).unwrap();
         let t = t.get().expect("pg_catalog is broken.");

--- a/src/datatype/memory_vecf32.rs
+++ b/src/datatype/memory_vecf32.rs
@@ -13,6 +13,8 @@ use std::alloc::Layout;
 use std::ops::Deref;
 use std::ptr::NonNull;
 
+use crate::schema::pgvectors_schema_cstr;
+
 #[repr(C, align(8))]
 pub struct Vecf32Header {
     varlena: u32,
@@ -136,7 +138,9 @@ impl IntoDatum for Vecf32Output {
     }
 
     fn type_oid() -> Oid {
-        let namespace = pgrx::pg_catalog::PgNamespace::search_namespacename(c"vectors").unwrap();
+        let namespace =
+            pgrx::pg_catalog::PgNamespace::search_namespacename(&pgvectors_schema_cstr())
+                .expect("namespace unknown?");
         let namespace = namespace.get().expect("pgvecto.rs is not installed.");
         let t = pgrx::pg_catalog::PgType::search_typenamensp(c"vector", namespace.oid()).unwrap();
         let t = t.get().expect("pg_catalog is broken.");

--- a/src/datatype/memory_veci8.rs
+++ b/src/datatype/memory_veci8.rs
@@ -14,6 +14,8 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ptr::NonNull;
 
+use crate::schema::pgvectors_schema_cstr;
+
 pub const VECI8_KIND: u16 = 4;
 
 /// Veci8 utilizes int8 for data storage, originally derived from Vecf32.
@@ -198,7 +200,8 @@ impl IntoDatum for Veci8Output {
     }
 
     fn type_oid() -> Oid {
-        let namespace = pgrx::pg_catalog::PgNamespace::search_namespacename(c"vectors").unwrap();
+        let namespace =
+            pgrx::pg_catalog::PgNamespace::search_namespacename(&pgvectors_schema_cstr()).unwrap();
         let namespace = namespace.get().expect("pgvecto.rs is not installed.");
         let t = pgrx::pg_catalog::PgType::search_typenamensp(c"veci8", namespace.oid()).unwrap();
         let t = t.get().expect("pg_catalog is broken.");

--- a/src/index/am_options.rs
+++ b/src/index/am_options.rs
@@ -1,5 +1,6 @@
 use crate::datatype::typmod::Typmod;
 use crate::error::*;
+use crate::schema::pgvectors_schema_cstr;
 use base::distance::*;
 use base::index::*;
 use base::vector::*;
@@ -30,7 +31,8 @@ impl Reloption {
 }
 
 pub fn convert_opclass_to_vd(opclass_oid: pgrx::pg_sys::Oid) -> Option<(VectorKind, DistanceKind)> {
-    let namespace = pgrx::pg_catalog::PgNamespace::search_namespacename(c"vectors").unwrap();
+    let namespace =
+        pgrx::pg_catalog::PgNamespace::search_namespacename(&pgvectors_schema_cstr()).unwrap();
     let namespace = namespace.get().expect("pgvecto.rs is not installed.");
     let opclass = pgrx::pg_catalog::PgOpclass::search_claoid(opclass_oid).unwrap();
     let opclass = opclass.get().expect("pg_catalog is broken.");
@@ -47,7 +49,8 @@ pub fn convert_opclass_to_vd(opclass_oid: pgrx::pg_sys::Oid) -> Option<(VectorKi
 pub fn convert_opfamily_to_vd(
     opfamily_oid: pgrx::pg_sys::Oid,
 ) -> Option<(VectorKind, DistanceKind)> {
-    let namespace = pgrx::pg_catalog::PgNamespace::search_namespacename(c"vectors").unwrap();
+    let namespace =
+        pgrx::pg_catalog::PgNamespace::search_namespacename(&pgvectors_schema_cstr()).unwrap();
     let namespace = namespace.get().expect("pgvecto.rs is not installed.");
     let opfamily = pgrx::pg_catalog::PgOpfamily::search_opfamilyoid(opfamily_oid).unwrap();
     let opfamily = opfamily.get().expect("pg_catalog is broken.");

--- a/src/index/views.rs
+++ b/src/index/views.rs
@@ -1,6 +1,7 @@
 use crate::error::*;
 use crate::index::utils::from_oid_to_handle;
 use crate::ipc::client;
+use crate::schema::pgvectors_index_stat_name;
 use base::index::*;
 use pgrx::error;
 
@@ -17,10 +18,10 @@ fn _vectors_alter_vector_index(oid: pgrx::pg_sys::Oid, key: String, value: Strin
 #[pgrx::pg_extern(volatile, strict, parallel_safe)]
 fn _vectors_index_stat(
     oid: pgrx::pg_sys::Oid,
-) -> pgrx::composite_type!('static, "vectors.vector_index_stat") {
+) -> pgrx::composite_type!('static, pgvectors_index_stat_name()) {
     use pgrx::heap_tuple::PgHeapTuple;
     let handle = from_oid_to_handle(oid);
-    let mut res = PgHeapTuple::new_composite_type("vectors.vector_index_stat").unwrap();
+    let mut res = PgHeapTuple::new_composite_type(&pgvectors_index_stat_name()).unwrap();
     let mut rpc = check_client(client());
     let stat = rpc.stat(handle);
     match stat {

--- a/src/index/views.rs
+++ b/src/index/views.rs
@@ -21,7 +21,7 @@ fn _vectors_index_stat(
 ) -> pgrx::composite_type!('static, pgvectors_index_stat_name()) {
     use pgrx::heap_tuple::PgHeapTuple;
     let handle = from_oid_to_handle(oid);
-    let mut res = PgHeapTuple::new_composite_type(&pgvectors_index_stat_name()).unwrap();
+    let mut res = PgHeapTuple::new_composite_type(pgvectors_index_stat_name()).unwrap();
     let mut rpc = check_client(client());
     let stat = rpc.stat(handle);
     match stat {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod error;
 mod gucs;
 mod index;
 mod ipc;
+mod schema;
 mod upgrade;
 mod utils;
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,21 @@
+use std::ffi::CString;
+use std::option_env;
+
+const fn pgvectors_schema() -> &'static str {
+    match option_env!("PGVECTORS_SCHEMA") {
+        Some(val) => val,
+        None => "vectors",
+    }
+}
+
+pub(crate) const fn pgvectors_index_stat_name() -> &'static str {
+    match option_env!("PGVECTORS_STAT_NAME") {
+        Some(val) => val,
+        None => "vectors.vector_index_stat",
+    }
+}
+
+pub(crate) fn pgvectors_schema_cstr() -> CString {
+    // CString is not a const func
+    CString::new(pgvectors_schema()).expect("failed to convert the schema name to a c-string")
+}


### PR DESCRIPTION
This PR supports changing the schema name in the compile time.

- sed the control file
- set the env of
  - `PGVECTORS_SCHEMA`
  - `PGVECTORS_STAT_NAME`