### PR TITLE
fix: skip partitioned tables in `pg_vector_index_stat`

### DIFF
--- a/src/sql/finalize.sql
+++ b/src/sql/finalize.sql
@@ -775,7 +775,7 @@ CREATE VIEW pg_vector_index_stat AS
          pg_index X ON C.oid = X.indrelid JOIN
          pg_class I ON I.oid = X.indexrelid JOIN
          pg_am A ON A.oid = I.relam
-    WHERE A.amname = 'vectors';
+    WHERE A.amname = 'vectors' AND C.relkind = 'r';
 
 GRANT SELECT ON TABLE pg_vector_index_stat TO PUBLIC;
 


### PR DESCRIPTION
closes #477