### PR TITLE
ci: lock version of sqllogictest-bin

### DIFF
--- a/.github/workflows/psql.yml
+++ b/.github/workflows/psql.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Set up cargo-binstall
         uses: cargo-bins/cargo-binstall@main
       - name: Set up Sqllogictest
-        run: cargo binstall sqllogictest-bin -y --force
+        run: cargo binstall sqllogictest-bin --version 0.20.6 -y --force
       - name: Test
         run: ./tests/tests.sh
       - name: Post Set up Cache


### PR DESCRIPTION
`sqllogictest-bin` fails to build on CI sometimes, causing that `cargo-binstall` on CI does not really work.