### PR TITLE
fix: `parse_vector` for f32s with a 48-char representation

### DIFF
--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -52,9 +52,6 @@ where
         let c = input[position];
         match c {
             b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'.' | b'+' | b'-' => {
-                if token.is_empty() {
-                    token.push(b'$');
-                }
                 if token.try_push(c).is_err() {
                     return Err(ParseVectorError::TooLongNumber { position });
                 }
@@ -62,7 +59,7 @@ where
             b',' => {
                 if !token.is_empty() {
                     // Safety: all bytes in `token` are ascii characters
-                    let s = unsafe { std::str::from_utf8_unchecked(&token[1..]) };
+                    let s = unsafe { std::str::from_utf8_unchecked(&token) };
                     let num = f(s).ok_or(ParseVectorError::BadParsing { position })?;
                     vector.push(num);
                     token.clear();
@@ -77,7 +74,7 @@ where
     if !token.is_empty() {
         let position = right;
         // Safety: all bytes in `token` are ascii characters
-        let s = unsafe { std::str::from_utf8_unchecked(&token[1..]) };
+        let s = unsafe { std::str::from_utf8_unchecked(&token) };
         let num = f(s).ok_or(ParseVectorError::BadParsing { position })?;
         vector.push(num);
         token.clear();


### PR DESCRIPTION
Howdy, thanks for such a cool project! I found an issue parsing vectors containg values with 48 character representations.
For example [`-0.000000000000000000000000000000000000023509886`, a valid f32  given by `0x80FFFFFF`](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=39b6c9c8278bae0a11a440f82aaefa74) with length 48.
I ran into this because I had saved a vector with this value in a prior version of pgvecto.rs (0.2.1) and was running into the `Bad literal` error when importing the same data into version 0.3.0.

I believe that the tokenizer in `parse_vector` is prepending a superfluous `'$'` into the token buffer. This PR removes it. 

### Before
```
vectors=# CREATE TABLE items (embedding vector(3));
vectors=# insert into items VALUES ('[0.3,-1.3,-0.000000000000000000000000000000000000023509886]');
ERROR:  pgvecto.rs: Bad literal.
INFORMATION: hint = Too long number at position 52
LINE 1: insert into items VALUES ('[0.3,-1.3,-0.0000000000000000000000000...
```

### After
```
  vectors=# insert into items VALUES ('[0.3,-1.3,-0.000000000000000000000000000000000000023509886]');
  INSERT 0 1
  vectors=# select * from items;
                          embedding                         
  ----------------------------------------------------------
   [0.3, -1.3, -0.000000000000000000000000000000000000023509886]
  (1 row)
```

### Discussion 
Taking Chesterson's fence to heart, I really did try squinting every which way to figure out why the `'$'` is pushed to `token` at first but came up blank. I think it may have been testing code in the initial benchmark rig that @usamoi was using when speeding up the parsing (https://github.com/tensorchord/pgvecto.rs/pull/316)? At any rate, if it is required I think that the [buffer on line 50](https://github.com/tensorchord/pgvecto.rs/compare/main...alexquick:pgvecto.rs:fix-parse-vector?expand=1#diff-f3463672da11eddc5a4db9d46d51725082a9062f7ad184d1298aaf5dedc36fcbR50) needs to be constructed with len=49 rather than 48 to account for the extra `'$'`. Note that very similar code [parse_pgvector_svector](https://github.com/tensorchord/pgvecto.rs/blob/152f94aceaf9480dd8012e9901721ecd140d7f10/src/utils/parse.rs#L102) does not seem to be affected by this issue.