### PR TITLE
refactor: use transposed centroids in PQ preprocess

### DIFF
--- a/crates/base/src/index.rs
+++ b/crates/base/src/index.rs
@@ -476,7 +476,7 @@ impl Default for ScalarQuantizationOptions {
 #[validate(schema(function = "Self::validate_self"))]
 pub struct ProductQuantizationOptions {
     #[serde(default = "ProductQuantizationOptions::default_ratio")]
-    #[validate(range(min = 1, max = 1024))]
+    #[validate(range(min = 1, max = 8))]
     pub ratio: u32,
     #[serde(default = "ProductQuantizationOptions::default_bits")]
     pub bits: u32,


### PR DESCRIPTION
With this PR, on GIST, (nlist = 4096, residual_quantization = true; nprobe = 300)
* IVF-RQ 0.9843 2.5s
* IVF-PQ 0.9914 3.3s (ratio = 2, bits = 2; pq_rerank_size = 100)